### PR TITLE
fix: prevent iOS Safari from overlapping footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -394,6 +394,7 @@
     <!-- Footer -->
     <footer
       class="pointer-events-none fixed inset-x-0 bottom-4 z-10 text-center text-stone-500"
+      style="bottom: calc(env(safe-area-inset-bottom) + 1rem)"
     >
       <div class="text-sm">© 2025 Predictive Text Labs</div>
     </footer>


### PR DESCRIPTION
## Summary
- ensure footer respects iOS safe area so Safari's toolbar doesn't overlap text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run format:check` *(warn: Code style issues found in 3 files. Run Prettier with --write to fix.)*
- `npm run build:css` *(fails: No prebuild or local build of @parcel/watcher found.)*

------
https://chatgpt.com/codex/tasks/task_e_68b72a747d248327820ae08f2be30379