### PR TITLE
fix: stabilize footer in iOS Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,13 +151,13 @@
       /* Radial oval sizing for footer backdrop */
       :root {
         --oval-rx: 100vw; /* full viewport width */
-        --oval-ry: 10rem; /* mobile & tablet visible height */
+        --oval-ry: 16rem; /* extended visible height */
       }
       @media (min-width: 1024px) {
         /* desktop */
         :root {
           --oval-rx: 100vw; /* full viewport width */
-          --oval-ry: 14rem; /* desktop visible height */
+          --oval-ry: 16rem; /* extended visible height */
         }
       }
     </style>

--- a/index.html
+++ b/index.html
@@ -393,7 +393,7 @@
     </main>
     <!-- Footer -->
     <footer
-      class="pointer-events-none fixed inset-x-0 bottom-4 z-10 text-center text-stone-500"
+      class="pointer-events-none fixed inset-x-0 bottom-[calc(env(safe-area-inset-bottom)+1rem)] z-10 text-center text-stone-500"
     >
       <div class="text-sm">© 2025 Predictive Text Labs</div>
     </footer>

--- a/index.html
+++ b/index.html
@@ -397,5 +397,27 @@
     >
       <div class="text-sm">© 2025 Predictive Text Labs</div>
     </footer>
+    <div
+      id="ios-footer-gradient"
+      class="pointer-events-none fixed inset-x-0 bottom-0 z-0 hidden h-[calc(env(safe-area-inset-bottom)+5rem)]"
+      style="
+        background: radial-gradient(
+          50% 160% at 50% 100%,
+          white,
+          rgba(255, 255, 255, 0)
+        );
+      "
+    ></div>
+    <script>
+      const ua = window.navigator.userAgent;
+      const isIOS = /iP(hone|od|ad)/.test(ua);
+      const isSafari =
+        /Safari/.test(ua) && !/Chrome|CriOS|FxiOS|EdgiOS|OPiOS/.test(ua);
+      if (isIOS && isSafari) {
+        document
+          .getElementById("ios-footer-gradient")
+          ?.classList.remove("hidden");
+      }
+    </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -151,13 +151,13 @@
       /* Radial oval sizing for footer backdrop */
       :root {
         --oval-rx: 100vw; /* full viewport width */
-        --oval-ry: 8rem; /* mobile & tablet visible height */
+        --oval-ry: 10rem; /* mobile & tablet visible height */
       }
       @media (min-width: 1024px) {
         /* desktop */
         :root {
           --oval-rx: 100vw; /* full viewport width */
-          --oval-ry: 12rem; /* desktop visible height */
+          --oval-ry: 14rem; /* desktop visible height */
         }
       }
     </style>
@@ -399,10 +399,11 @@
     </footer>
     <div
       id="ios-footer-gradient"
-      class="pointer-events-none fixed inset-x-0 bottom-0 z-0 hidden h-[calc(env(safe-area-inset-bottom)+5rem)]"
+      class="pointer-events-none fixed inset-x-0 bottom-0 z-0 hidden"
       style="
+        height: calc(env(safe-area-inset-bottom) + var(--oval-ry));
         background: radial-gradient(
-          50% 160% at 50% 100%,
+          var(--oval-rx) var(--oval-ry) at 50% 100%,
           white,
           rgba(255, 255, 255, 0)
         );


### PR DESCRIPTION
## Summary
- offset footer by safe-area inset to avoid iOS Safari toolbar gaps

## Testing
- `npm run format:check` *(warn: existing files need formatting)*

------
https://chatgpt.com/codex/tasks/task_e_68b72a747d248327820ae08f2be30379