### PR TITLE
Make Safari 26 tint its bar with the page's ground

### DIFF
--- a/about.html
+++ b/about.html
@@ -224,20 +224,40 @@
           mask-image: none;
         }
       }
-      /* Safari 26 tints its own chrome from the page rather than letting the
-     page paint there: it looks for a `position: fixed` element against each
-     viewport edge and takes that element's `background-color`. The film is the
-     fixed layer against both edges here, so it is the one that answers, and it
-     answers with the page's own ground. The opacity a thousandth off 1 is what
-     stops Safari treating a full-screen fixed layer as a plain fill it can
-     clip. The veil is left alone: it sits over the film and has to stay
-     translucent, and a translucent layer offered to Safari is read as light.
-     -webkit-touch-callout is the guard because only iOS has both the behaviour
-     and the property, so no other engine pays for a layer it does not need. */
+      /* THE FILM REACHES THE BOTTOM OF THE SCREEN. The front page carries the
+     long version of this; the short one is that iOS 26 lays a translucent bar
+     over the last ~60pt of the screen, and a `position: fixed` layer is sized
+     to the layout viewport and clipped there, so the film stopped short and
+     the glass showed the page's own ground instead. No viewport unit reaches
+     the rest — 100lvh measures 754 on an 874pt screen, because the pocket the
+     bar sits in never retracts.
+
+     The scrolling layer is not clipped, so the film is unfixed and carried
+     down the document (PTLField.pin) with --film-bleed of extra picture below
+     the frame. ptl-field.js composes against the frame, not the buffer, so
+     nothing above the bar moves.
+
+     The veil stays fixed: it is the defocus sheet the copy is read on, its
+     mask is written against the frame, and it has no business under the bar. */
       @supports (-webkit-touch-callout: none) {
         #c {
-          background: var(--paper);
-          opacity: 0.999;
+          --film-bleed: 140px;
+          position: absolute;
+          top: 0;
+          bottom: auto;
+          height: calc(100lvh + var(--film-bleed));
+          will-change: transform;
+        }
+        @supports (animation-timeline: scroll()) {
+          #c {
+            animation: film-follow linear both;
+            animation-timeline: scroll(root block);
+          }
+        }
+      }
+      @keyframes film-follow {
+        to {
+          transform: translateY(var(--film-travel, 0px));
         }
       }
 
@@ -979,6 +999,13 @@
           typeof PTLField !== "undefined"
             ? PTLField.mount(document.getElementById("c"), { mode: "form" })
             : null;
+        /* A no-op on every engine that still has the film fixed; on iOS it is
+           what carries the unfixed film down the document. This page's height
+           is the document's own, so there is nothing to wait for. */
+        const followFilm =
+          typeof PTLField !== "undefined"
+            ? PTLField.pin(document.getElementById("c"))
+            : () => {};
 
         /* OPEN is where the mark sits when the reader lands: exactly where the
      front page left it, closed. Scrolling opens it back out to WIDE and it
@@ -1085,6 +1112,7 @@
         let ticking = 0;
 
         function render() {
+          followFilm();
           if (!field || field.isDead()) return;
           const max = root.scrollHeight - innerHeight;
           const p = max > 0 ? clamp(window.scrollY / max) : 0;

--- a/about.html
+++ b/about.html
@@ -224,19 +224,19 @@
           mask-image: none;
         }
       }
-      /* iOS 26 clips a full-screen `position: fixed` layer to the band between
-     Safari's status bar and its floating toolbar. This page's film and its veil
-     are both such layers, so both stopped short of the top and bottom edges and
-     the paper showed through where the picture should be. It is not the safe
-     area — `viewport-fit=cover` is already set. Safari only clips a fixed layer
-     it can treat as a plain fill; an opacity below 1 sends it through the
-     compositor instead and it paints the whole screen. 0.999 is the smallest
-     step off 1 that is still off it, and at this size it is not a colour.
-     -webkit-touch-callout is the guard because only iOS has both the bug and
-     the property, so no other engine pays for a layer it does not need. */
+      /* Safari 26 tints its own chrome from the page rather than letting the
+     page paint there: it looks for a `position: fixed` element against each
+     viewport edge and takes that element's `background-color`. The film is the
+     fixed layer against both edges here, so it is the one that answers, and it
+     answers with the page's own ground. The opacity a thousandth off 1 is what
+     stops Safari treating a full-screen fixed layer as a plain fill it can
+     clip. The veil is left alone: it sits over the film and has to stay
+     translucent, and a translucent layer offered to Safari is read as light.
+     -webkit-touch-callout is the guard because only iOS has both the behaviour
+     and the property, so no other engine pays for a layer it does not need. */
       @supports (-webkit-touch-callout: none) {
-        #c,
-        .veil {
+        #c {
+          background: var(--paper);
           opacity: 0.999;
         }
       }

--- a/about.html
+++ b/about.html
@@ -224,6 +224,23 @@
           mask-image: none;
         }
       }
+      /* iOS 26 clips a full-screen `position: fixed` layer to the band between
+     Safari's status bar and its floating toolbar. This page's film and its veil
+     are both such layers, so both stopped short of the top and bottom edges and
+     the paper showed through where the picture should be. It is not the safe
+     area — `viewport-fit=cover` is already set. Safari only clips a fixed layer
+     it can treat as a plain fill; an opacity below 1 sends it through the
+     compositor instead and it paints the whole screen. 0.999 is the smallest
+     step off 1 that is still off it, and at this size it is not a colour.
+     -webkit-touch-callout is the guard because only iOS has both the bug and
+     the property, so no other engine pays for a layer it does not need. */
+      @supports (-webkit-touch-callout: none) {
+        #c,
+        .veil {
+          opacity: 0.999;
+        }
+      }
+
       .page {
         position: relative;
         z-index: 2;

--- a/about.html
+++ b/about.html
@@ -238,8 +238,15 @@
      nothing above the bar moves.
 
      The veil stays fixed: it is the defocus sheet the copy is read on, its
-     mask is written against the frame, and it has no business under the bar. */
-      @supports (-webkit-touch-callout: none) {
+     mask is written against the frame, and it has no business under the bar.
+
+     The guard is three conditions for the reasons the front page gives at
+     length: iOS only, 100lvh because before 15.4 the height would be dropped
+     and this rule has already taken bottom:0 away, and a scroll timeline
+     because carrying the layer from script would re-extend the document on
+     every frame and the page would never end. */
+      @supports (-webkit-touch-callout: none) and (height: 100lvh) and
+        (animation-timeline: scroll()) {
         #c {
           --film-bleed: 140px;
           position: absolute;
@@ -248,11 +255,9 @@
           height: calc(100lvh + var(--film-bleed));
           will-change: transform;
         }
-        @supports (animation-timeline: scroll()) {
-          #c {
-            animation: film-follow linear both;
-            animation-timeline: scroll(root block);
-          }
+        #c {
+          animation: film-follow linear both;
+          animation-timeline: scroll(root block);
         }
       }
       @keyframes film-follow {
@@ -1002,10 +1007,9 @@
         /* A no-op on every engine that still has the film fixed; on iOS it is
            what carries the unfixed film down the document. This page's height
            is the document's own, so there is nothing to wait for. */
-        const followFilm =
-          typeof PTLField !== "undefined"
-            ? PTLField.pin(document.getElementById("c"))
-            : () => {};
+        if (typeof PTLField !== "undefined") {
+          PTLField.pin(document.getElementById("c"));
+        }
 
         /* OPEN is where the mark sits when the reader lands: exactly where the
      front page left it, closed. Scrolling opens it back out to WIDE and it
@@ -1112,7 +1116,6 @@
         let ticking = 0;
 
         function render() {
-          followFilm();
           if (!field || field.isDead()) return;
           const max = root.scrollHeight - innerHeight;
           const p = max > 0 ? clamp(window.scrollY / max) : 0;

--- a/about.html
+++ b/about.html
@@ -247,15 +247,20 @@
      every frame and the page would never end. */
       @supports (-webkit-touch-callout: none) and (height: 100lvh) and
         (animation-timeline: scroll()) {
-        #c {
-          --film-bleed: 140px;
+        :root[data-film-pinned] #c {
+          /* Twelve halftone cells, not a round number — see index.html: the
+             lattice counts cells up from the buffer, so a bleed that is not a
+             whole number of them moves every mark in the frame. And gated on
+             the attribute PTLField.pin sets, so the film is never unfixed
+             unless something is there to carry it. */
+          --film-bleed: 144px;
           position: absolute;
           top: 0;
           bottom: auto;
           height: calc(100lvh + var(--film-bleed));
           will-change: transform;
         }
-        #c {
+        :root[data-film-pinned] #c {
           animation: film-follow linear both;
           animation-timeline: scroll(root block);
         }

--- a/about.html
+++ b/about.html
@@ -1010,9 +1010,15 @@
             ? PTLField.mount(document.getElementById("c"), { mode: "form" })
             : null;
         /* A no-op on every engine that still has the film fixed; on iOS it is
-           what carries the unfixed film down the document. This page's height
-           is the document's own, so there is nothing to wait for. */
-        if (typeof PTLField !== "undefined") {
+           what carries the unfixed film down the document.
+
+           Keyed to the FIELD, not to the namespace. mount() returns null when
+           there is no WebGL2 or the program will not build, and an unfixed
+           canvas with no renderer in it is all cost and no picture — a
+           composited layer, a scroll animation and a taller buffer, carrying
+           nothing. The page is a complete document without the film; it should
+           be the plain one it always was. */
+        if (field) {
           PTLField.pin(document.getElementById("c"));
         }
 

--- a/about.html
+++ b/about.html
@@ -161,6 +161,28 @@
         color: var(--ink-live, var(--ink));
         -webkit-font-smoothing: antialiased;
       }
+      /* THE CARRIED FILM MUST NOT LENGTHEN THE PAGE.
+     Once the film is unfixed it is moved by a transform, and a transform
+     counts towards scrollable overflow. The layer is one viewport plus a bleed
+     tall, so translated to the end of the document it hangs that bleed past
+     the bottom and the page grows. The page then has a NEW end, --film-travel
+     is republished against it, and the layer reaches further still. Measured
+     on iOS 26.5 with the film fixed the document is 4287 and never moves; with
+     it unfixed and nothing here, 4615 — and --film-travel ended up 184px stale,
+     which is the film sitting that far off its own frame at the bottom.
+
+     `clip` and not `hidden`: hidden makes body a scroll container, which is
+     what the front page happens to have, and it did NOT contain this — that
+     page is quiet for a different reason, its body height is set outright in
+     vh. clip creates no scroll container and contributes no scrollable
+     overflow at all, and the clip margin is what still lets the bleed paint
+     past the padding box, which is the entire point of having one. Measured
+     with this line: 4287 and GREW 0, travel exactly the page's own length, and
+     the film still reaching the bottom of the screen. */
+      body {
+        overflow: clip;
+        overflow-clip-margin: 300px;
+      }
       ::selection {
         background: var(--ink);
         color: var(--paper);

--- a/index.html
+++ b/index.html
@@ -370,20 +370,27 @@
       .type a {
         pointer-events: auto;
       }
-      /* iOS 26 clips a full-screen `position: fixed` layer to the band between
-     Safari's status bar and its floating toolbar, so the film stopped short of
-     both edges and the page's own black showed through — at the bottom of the
-     frame, which is the one place this page has no picture to lose. The clip is
-     not the safe area: `viewport-fit=cover` is already set and the chrome bar,
-     also fixed, draws where it should. Safari only clips a fixed layer it can
-     treat as a plain fill; an opacity below 1 sends it through the compositor
-     instead and it paints the whole screen. 0.999 is the smallest step off 1
-     that is still off it, and against this ground it is not a colour.
-     -webkit-touch-callout is the guard because only iOS has both the bug and
-     the property, so no other engine pays for a layer it does not need. */
+      /* Safari 26 tints its own chrome from the page rather than letting the
+     page paint there: it looks for a `position: fixed` element against each
+     viewport edge and takes that element's `background-color`. The bar at the
+     bottom of an iPhone is the result, and it is why the film appears to stop
+     short of the edge — it is not clipped, it is covered.
+
+     Two rules, and they are one idea. `.stage` gets the ground as a real
+     background-color so Safari has the page's own colour to read; it is behind
+     an opaque canvas, so nothing on the page can see it. And .stage takes an
+     opacity a thousandth off 1, which is what stops Safari treating a
+     full-screen fixed layer as a plain fill it can clip. `.type` is
+     deliberately NOT in either rule: it is the topmost fixed layer at the same
+     edge and it has to stay transparent for the film to show through, so
+     promoting it only offers Safari a transparent layer to sample — which is
+     read as light, and returns a white bar.
+
+     -webkit-touch-callout is the guard because only iOS has both the behaviour
+     and the property, so no other engine pays for a layer it does not need. */
       @supports (-webkit-touch-callout: none) {
-        .stage,
-        .type {
+        .stage {
+          background: var(--paper);
           opacity: 0.999;
         }
       }

--- a/index.html
+++ b/index.html
@@ -420,10 +420,28 @@
      Together they mean this only ever applies to Safari 26, which is the only
      thing that has the bar in the first place. Every older iOS keeps exactly
      the page it had. */
+      /* THE BLEED IS TWELVE HALFTONE CELLS, and that is not a round number
+     chosen for looking tidy. The lattice is anchored to the drawing buffer:
+     main() takes its cell id from gl_FragCoord, which counts up from the
+     buffer's bottom, so hanging rows underneath the frame moves the grid's
+     PHASE against the picture. At any bleed the frame's composition is
+     restored by uOrigin, but the lattice is not — 140px over a 12px cell is
+     11.67 cells, and every mark in the frame would sit 8 device pixels off
+     where it sits today. A whole number of cells shifts the cell INDEX by an
+     integer and nothing else: the centres land where they landed, and every
+     fract() in the shader is untouched. So this tracks the cell, not the
+     other way round. ptl-field.js snaps it again in size(), because a number
+     edited here by eye is exactly how the invariant gets lost.
+
+     Gated on data-film-pinned rather than the @supports alone, because the
+     layer must not be unfixed unless something is going to carry it. The
+     attribute is set by PTLField.pin; if the script never runs, the page
+     keeps the fixed film it has always had rather than a loose one parked at
+     the top of the document. */
       @supports (-webkit-touch-callout: none) and (height: 100lvh) and
         (animation-timeline: scroll()) {
-        .stage {
-          --film-bleed: 140px;
+        :root[data-film-pinned] .stage {
+          --film-bleed: 144px;
           position: absolute;
           top: 0;
           bottom: auto;
@@ -435,16 +453,16 @@
            OF THE FRAME and has to stay that way: the dome's mask is centred at
            50% 100%, which means the bottom of what the reader sees, and .deep's
            ramp runs from half of it. Left to inherit the taller box they would
-           both quietly slide 140px down the picture they were tuned against.
+           both quietly slide the bleed down the picture they were tuned against.
            So they keep the frame's height, and the bleed carries film alone —
            which is all that can be seen through the bar anyway. */
-        .stage > .deep,
-        .stage > .veil {
+        :root[data-film-pinned] .stage > .deep,
+        :root[data-film-pinned] .stage > .veil {
           bottom: var(--film-bleed);
         }
         /* The follow, run where the scrolling is. --film-travel is the
            document's own scrollable distance, published by PTLField.pin. */
-        .stage {
+        :root[data-film-pinned] .stage {
           animation: film-follow linear both;
           animation-timeline: scroll(root block);
         }

--- a/index.html
+++ b/index.html
@@ -370,28 +370,74 @@
       .type a {
         pointer-events: auto;
       }
-      /* Safari 26 tints its own chrome from the page rather than letting the
-     page paint there: it looks for a `position: fixed` element against each
-     viewport edge and takes that element's `background-color`. The bar at the
-     bottom of an iPhone is the result, and it is why the film appears to stop
-     short of the edge — it is not clipped, it is covered.
+      /* THE FILM REACHES THE BOTTOM OF THE SCREEN.
+     ------------------------------------------------------------------------
+     iOS 26 lays a translucent bar over the last ~60pt of the screen and shows
+     whatever the page has painted there through it. The film could not be
+     that, because it is `position: fixed`: WebKit sizes fixed boxes to the
+     LAYOUT viewport and clips their layer to it, so the picture stopped short
+     and what showed through the glass was the page's own ground — the black
+     band under the film.
 
-     Two rules, and they are one idea. `.stage` gets the ground as a real
-     background-color so Safari has the page's own colour to read; it is behind
-     an opaque canvas, so nothing on the page can see it. And .stage takes an
-     opacity a thousandth off 1, which is what stops Safari treating a
-     full-screen fixed layer as a plain fill it can clip. `.type` is
-     deliberately NOT in either rule: it is the topmost fixed layer at the same
-     edge and it has to stay transparent for the film to show through, so
-     promoting it only offers Safari a transparent layer to sample — which is
-     read as light, and returns a white bar.
+     Measured on iOS 26.5, 402x874pt: innerHeight is 754, and a fixed child
+     told to overhang by 200px is cut off exactly at the boundary rather than
+     painting past it. No viewport unit reaches the rest either — 100lvh is
+     also 754, because the pocket the bar sits in never retracts, so the LARGE
+     viewport does not include it. Nothing sized against the viewport can get
+     there while the layer is fixed.
+
+     The SCROLLING layer is not clipped. So on iOS the film is absolutely
+     positioned and carried down the document instead (PTLField.pin), with
+     --film-bleed of extra picture hung below the frame to fill the pocket.
+     The renderer is told those rows are bleed and keeps composing against the
+     frame — uOrigin in ptl-field.js — so nothing above the bar moves by a
+     pixel. The bleed is generous: it only has to be at least the pocket, and
+     rows nobody can see cost one shader pass each.
+
+     What this does NOT buy is a clean window. The glass attenuates the last
+     ~35pt, so the film reads through it rather than in it. That is Safari's
+     material and there is no lever on it.
+
+     `.type` stays fixed on purpose. It is the copy, it must never slide under
+     the bar, and it is the layer whose position a lagging transform would be
+     measured against.
 
      -webkit-touch-callout is the guard because only iOS has both the behaviour
-     and the property, so no other engine pays for a layer it does not need. */
+     and the property, so no other engine gives up a fixed layer for a
+     hand-carried one it has no need of. */
       @supports (-webkit-touch-callout: none) {
         .stage {
-          background: var(--paper);
-          opacity: 0.999;
+          --film-bleed: 140px;
+          position: absolute;
+          top: 0;
+          bottom: auto;
+          height: calc(100lvh + var(--film-bleed));
+          will-change: transform;
+        }
+        /* The canvas fills the taller box — it is the film, and the bleed is
+           what it is for. Everything else in .stage is measured in PERCENTAGES
+           OF THE FRAME and has to stay that way: the dome's mask is centred at
+           50% 100%, which means the bottom of what the reader sees, and .deep's
+           ramp runs from half of it. Left to inherit the taller box they would
+           both quietly slide 140px down the picture they were tuned against.
+           So they keep the frame's height, and the bleed carries film alone —
+           which is all that can be seen through the bar anyway. */
+        .stage > .deep,
+        .stage > .veil {
+          bottom: var(--film-bleed);
+        }
+        /* The follow, run where the scrolling is. --film-travel is the
+           document's own scrollable distance, published by PTLField.pin. */
+        @supports (animation-timeline: scroll()) {
+          .stage {
+            animation: film-follow linear both;
+            animation-timeline: scroll(root block);
+          }
+        }
+      }
+      @keyframes film-follow {
+        to {
+          transform: translateY(var(--film-travel, 0px));
         }
       }
       /* The LAYER is transparent to the pointer; the WORDS are not. Without this

--- a/index.html
+++ b/index.html
@@ -370,6 +370,23 @@
       .type a {
         pointer-events: auto;
       }
+      /* iOS 26 clips a full-screen `position: fixed` layer to the band between
+     Safari's status bar and its floating toolbar, so the film stopped short of
+     both edges and the page's own black showed through — at the bottom of the
+     frame, which is the one place this page has no picture to lose. The clip is
+     not the safe area: `viewport-fit=cover` is already set and the chrome bar,
+     also fixed, draws where it should. Safari only clips a fixed layer it can
+     treat as a plain fill; an opacity below 1 sends it through the compositor
+     instead and it paints the whole screen. 0.999 is the smallest step off 1
+     that is still off it, and against this ground it is not a colour.
+     -webkit-touch-callout is the guard because only iOS has both the bug and
+     the property, so no other engine pays for a layer it does not need. */
+      @supports (-webkit-touch-callout: none) {
+        .stage,
+        .type {
+          opacity: 0.999;
+        }
+      }
       /* The LAYER is transparent to the pointer; the WORDS are not. Without this
      the copy is text you cannot put a cursor in — no I-beam, no selection, no
      copying a line out of it — because the whole layer above the canvas was

--- a/index.html
+++ b/index.html
@@ -402,10 +402,26 @@
      the bar, and it is the layer whose position a lagging transform would be
      measured against.
 
-     -webkit-touch-callout is the guard because only iOS has both the behaviour
-     and the property, so no other engine gives up a fixed layer for a
-     hand-carried one it has no need of. */
-      @supports (-webkit-touch-callout: none) {
+     THE GUARD IS THREE THINGS, and each one is load-bearing.
+     -webkit-touch-callout because only iOS has the behaviour, so no other
+     engine gives up a fixed layer for a carried one it has no need of.
+     100lvh because iOS Safari before 15.4 does not have it: this rule also
+     replaces bottom:0 with bottom:auto, and a dropped height would leave the
+     stage sized by content — every child is absolutely positioned, so the film
+     would be one pixel tall and gone. A vh fallback declaration cannot save it
+     either, because the height carries a var(): it is validated after
+     substitution, and failing there means unset, not the previous declaration.
+     And a scroll timeline because that is what carries the layer. Doing it
+     from script instead is not a lesser version of this, it is a broken one —
+     a transform contributes to scrollable overflow, so a hand-written
+     translateY(scrollY) on a layer taller than the viewport re-extends the
+     document every frame and the page never reaches its end.
+
+     Together they mean this only ever applies to Safari 26, which is the only
+     thing that has the bar in the first place. Every older iOS keeps exactly
+     the page it had. */
+      @supports (-webkit-touch-callout: none) and (height: 100lvh) and
+        (animation-timeline: scroll()) {
         .stage {
           --film-bleed: 140px;
           position: absolute;
@@ -428,11 +444,9 @@
         }
         /* The follow, run where the scrolling is. --film-travel is the
            document's own scrollable distance, published by PTLField.pin. */
-        @supports (animation-timeline: scroll()) {
-          .stage {
-            animation: film-follow linear both;
-            animation-timeline: scroll(root block);
-          }
+        .stage {
+          animation: film-follow linear both;
+          animation-timeline: scroll(root block);
         }
       }
       @keyframes film-follow {

--- a/src/ptl-field.js
+++ b/src/ptl-field.js
@@ -1291,33 +1291,29 @@
   /* CARRYING AN UNFIXED FILM DOWN THE DOCUMENT.
      --------------------------------------------------------------------------
      The film cannot be position:fixed on iOS 26 — see --film-bleed in the page
-     for why — so where the page has unfixed it, it has to be carried by hand.
+     for why — so where the page has unfixed it, something has to carry it. The
+     page does that with a scroll timeline; all this publishes is the distance,
+     which is the document's own scrollable length.
 
-     Where the browser will run that on its own compositor, it must: a transform
-     written from script lags a fling, and the picture would swim against the
-     copy, which is still fixed and does not lag. A scroll timeline is the same
-     translation expressed as an animation, so it runs where the scrolling does.
-     Script is the fallback, and it is stepped from the same frame that draws the
-     film, so the two cannot disagree with each other even when both lag.
-
-     Returns that per-frame step, which is a no-op when the compositor has it —
-     deliberately not `travel`, which reads scrollHeight and would cost a forced
-     layout on every drawn frame to re-learn a number that moves once a session.
+     THERE IS DELIBERATELY NO SCRIPT FALLBACK. Writing the transform by hand is
+     not a lesser version of the timeline, it is a broken one: a transform
+     contributes to scrollable overflow, so translating a layer taller than the
+     viewport by scrollY puts its bottom permanently past the document's, which
+     extends scrollHeight, which moves the end further away — every frame, for
+     as long as the reader keeps going. The page would have no bottom. The
+     page's own @supports requires a scroll timeline for exactly this reason, so
+     an engine that cannot run one never unfixes the layer and never gets here.
 
      No-op unless the page actually unfixed the layer, so every other engine
      keeps the fixed layer it has no reason to give up. */
   function pin(el) {
-    if (!el || getComputedStyle(el).position !== 'absolute') return () => {};
+    if (!el || getComputedStyle(el).position !== 'absolute') return;
     const travel = () => el.style.setProperty(
       '--film-travel',
       Math.max(0, document.documentElement.scrollHeight - root.innerHeight) + 'px',
     );
     travel();
     root.addEventListener('resize', travel);
-    if (root.CSS && CSS.supports('animation-timeline', 'scroll()')) return () => {};
-    return () => {
-      el.style.transform = 'translate3d(0,' + root.scrollY + 'px,0)';
-    };
   }
 
   root.PTLField = { mount, pin, CLOSE };

--- a/src/ptl-field.js
+++ b/src/ptl-field.js
@@ -69,7 +69,14 @@
   precision highp float;
   out vec4 fragColor;
 
+  /* uRes is THE FRAME — what the reader is composed against — and not
+     necessarily the whole buffer. On iOS the buffer is given extra rows below
+     the frame so the film can paint into the strip the toolbar sits over (see
+     --film-bleed in the page). uOrigin is where the frame's bottom-left sits
+     inside that buffer, so every measurement below still means what it says:
+     a share of the frame, unmoved by how much bleed is hung underneath it. */
   uniform vec2      uRes;
+  uniform vec2      uOrigin;    // frame's bottom-left within the buffer, device px
   uniform float     uT;         // 0..1 progress through this section
   uniform float     uCell;      // grid cell size in device px
   uniform float     uGap;       // black gutter between cells
@@ -463,7 +470,7 @@
      positional — so one id in, one size out, and a fragment can ask about its
      neighbours on the same terms it asks about itself. */
   vec2 cellUv(vec2 id){
-    return ((id + 0.5) * uCell - 0.5 * uRes) / baseOf();
+    return ((id + 0.5) * uCell - uOrigin - 0.5 * uRes) / baseOf();
   }
 
   /* THE PICTURE, SAMPLED AT ONE CELL. This is the only place the form is ever
@@ -525,7 +532,7 @@
        field on a letterboxed canvas instead of cropping it, which shrank the
        subject to a stamp in the middle of a very wide empty frame. */
     float base = baseOf();
-    vec2 uv = (centre - 0.5 * uRes) / base;
+    vec2 uv = (centre - uOrigin - 0.5 * uRes) / base;
     float halfH = 0.5 * uRes.y / base;
 
     /* THE GROUND IS THE SAME PICTURE THE MARKS ARE, AT THE SAME RESOLUTION.
@@ -1036,6 +1043,9 @@
        defaults, and leaving the cache populated would let size() decide there
        was nothing to re-apply. */
     let w = 0, h = 0;
+    /* The frame is the part of the buffer the reader sees. `bleed` is the rows
+       hung below it, which exist only to be painted over by browser chrome. */
+    let bleed = 0, frameH = 0;
     /* Set only if a REBUILD fails — the context came back and would not take
        the program. Nothing can be drawn again after that, so the page stops
        asking rather than calling draw() on every scroll frame forever. */
@@ -1067,7 +1077,7 @@
       return p;
     }
 
-    const UNIFORMS = ['uRes', 'uT', 'uG', 'uCell', 'uGap', 'uGain', 'uMode',
+    const UNIFORMS = ['uRes', 'uOrigin', 'uT', 'uG', 'uCell', 'uGap', 'uGain', 'uMode',
                       'uSection', 'uTex', 'uLat', 'uFov', 'uMouse', 'uAct',
                       'uTime', 'uAmb', 'uInk', 'uInk2', 'uPaper', 'uTint',
                       'uShadow', 'uTone', 'uResolve', 'uPrint', 'uCopy', 'uLift'];
@@ -1183,6 +1193,14 @@
       const nh = Math.round(canvas.clientHeight * dpr);
       if (nw === w && nh === h) return;
       w = canvas.width = nw; h = canvas.height = nh;
+      /* Read only when the size actually changed — getComputedStyle every
+         frame would cost a style resolve per draw for a number that moves
+         about once a session. */
+      const css = parseFloat(
+        getComputedStyle(canvas).getPropertyValue('--film-bleed'),
+      );
+      bleed  = Math.min(h - 1, Math.max(0, Math.round((css || 0) * dpr)));
+      frameH = h - bleed;
       gl.viewport(0, 0, w, h);
     }
 
@@ -1193,7 +1211,8 @@
       gl.useProgram(p);
       gl.uniform1i(uu.uTex, 0);
       gl.uniform1i(uu.uLat, 1);
-      gl.uniform2f(uu.uRes, w, h);
+      gl.uniform2f(uu.uRes, w, frameH);
+      gl.uniform2f(uu.uOrigin, 0, bleed);
       gl.uniform1f(uu.uT, t);
       gl.uniform1f(uu.uG, o.g != null ? o.g : t);
       gl.uniform1f(uu.uCell, (o.cell != null ? o.cell : 12) * dpr);
@@ -1269,5 +1288,37 @@
     return { draw, setWord, gl, canvas, isDead: () => dead, isLost: () => lost };
   }
 
-  root.PTLField = { mount, CLOSE };
+  /* CARRYING AN UNFIXED FILM DOWN THE DOCUMENT.
+     --------------------------------------------------------------------------
+     The film cannot be position:fixed on iOS 26 — see --film-bleed in the page
+     for why — so where the page has unfixed it, it has to be carried by hand.
+
+     Where the browser will run that on its own compositor, it must: a transform
+     written from script lags a fling, and the picture would swim against the
+     copy, which is still fixed and does not lag. A scroll timeline is the same
+     translation expressed as an animation, so it runs where the scrolling does.
+     Script is the fallback, and it is stepped from the same frame that draws the
+     film, so the two cannot disagree with each other even when both lag.
+
+     Returns that per-frame step, which is a no-op when the compositor has it —
+     deliberately not `travel`, which reads scrollHeight and would cost a forced
+     layout on every drawn frame to re-learn a number that moves once a session.
+
+     No-op unless the page actually unfixed the layer, so every other engine
+     keeps the fixed layer it has no reason to give up. */
+  function pin(el) {
+    if (!el || getComputedStyle(el).position !== 'absolute') return () => {};
+    const travel = () => el.style.setProperty(
+      '--film-travel',
+      Math.max(0, document.documentElement.scrollHeight - root.innerHeight) + 'px',
+    );
+    travel();
+    root.addEventListener('resize', travel);
+    if (root.CSS && CSS.supports('animation-timeline', 'scroll()')) return () => {};
+    return () => {
+      el.style.transform = 'translate3d(0,' + root.scrollY + 'px,0)';
+    };
+  }
+
+  root.PTLField = { mount, pin, CLOSE };
 })(window);

--- a/src/ptl-field.js
+++ b/src/ptl-field.js
@@ -1199,7 +1199,18 @@
       const css = parseFloat(
         getComputedStyle(canvas).getPropertyValue('--film-bleed'),
       );
-      bleed  = Math.min(h - 1, Math.max(0, Math.round((css || 0) * dpr)));
+      /* SNAPPED TO WHOLE HALFTONE CELLS. uOrigin restores the frame's
+         composition, but it cannot restore the LATTICE: main() takes its cell
+         id from gl_FragCoord, which counts up from the bottom of the buffer,
+         so rows hung underneath the frame move the grid's phase against the
+         picture. A bleed of a whole number of cells shifts the cell index by
+         an integer and changes nothing else — the centres land where they
+         landed and every fract() is untouched. The page is written to be a
+         whole number already; this is here so that editing that number by eye
+         cannot quietly move every mark in the frame. */
+      const cellPx = 12 * dpr;             // the cell both pages draw with
+      const want   = Math.max(0, (css || 0) * dpr);
+      bleed  = Math.min(h - 1, Math.round(want / cellPx) * cellPx);
       frameH = h - bleed;
       gl.viewport(0, 0, w, h);
     }
@@ -1307,13 +1318,34 @@
      No-op unless the page actually unfixed the layer, so every other engine
      keeps the fixed layer it has no reason to give up. */
   function pin(el) {
-    if (!el || getComputedStyle(el).position !== 'absolute') return;
-    const travel = () => el.style.setProperty(
-      '--film-travel',
-      Math.max(0, document.documentElement.scrollHeight - root.innerHeight) + 'px',
-    );
+    if (!el) return;
+    /* The attribute goes on FIRST and comes off again if it did not take. The
+       page gates the whole treatment on it, so the layer cannot be unfixed by
+       a stylesheet that arrived without the script to carry it — and that
+       gating is also why position has to be read after setting it, not
+       before: before, it is still fixed by definition. */
+    const doc = document.documentElement;
+    doc.dataset.filmPinned = '';
+    if (getComputedStyle(el).position !== 'absolute') {
+      delete doc.dataset.filmPinned;
+      return;
+    }
+    let last = '';
+    const travel = () => {
+      const v = Math.max(0, doc.scrollHeight - root.innerHeight) + 'px';
+      if (v === last) return;              // no write, so no observer feedback
+      last = v;
+      el.style.setProperty('--film-travel', v);
+    };
     travel();
     root.addEventListener('resize', travel);
+    /* The front page sets its own height in vh and is final at once. The about
+       page is ordinary content, and its faces are font-display:block: when
+       they land, lines re-wrap and the document changes height under a number
+       we have already published. Measured once, the film would end up short or
+       long by that difference at the bottom of the page. */
+    if (document.fonts && document.fonts.ready) document.fonts.ready.then(travel);
+    if (root.ResizeObserver) new ResizeObserver(travel).observe(document.body);
   }
 
   root.PTLField = { mount, pin, CLOSE };

--- a/src/ptl-page.js
+++ b/src/ptl-page.js
@@ -783,9 +783,9 @@
      Guarded like every other reach for PTLField in this file, and for the
      reason given above mount: the name is undeclared when the script is
      missing, so touching it at all is a ReferenceError, not a falsy read. */
-  const followFilm = typeof PTLField !== 'undefined'
-    ? PTLField.pin(document.querySelector('.stage'))
-    : () => {};
+  if (typeof PTLField !== 'undefined') {
+    PTLField.pin(document.querySelector('.stage'));
+  }
   let raf = 0, shown = -1, remeasure = false, lastW = innerWidth;
   let endU = -1;                          // last published --ending
   let resU = '';                          // last published --resolved
@@ -801,11 +801,6 @@
   let still = false;
 
   function render() {
-    /* Here rather than in frame(), because this is the one place that draws:
-       the ambient loop reaches it too, and during a scroll with ambient
-       running frame() is skipped entirely. A drawn film that did not move
-       with the page would be worse than either. */
-    followFilm();
     const max  = document.documentElement.scrollHeight - innerHeight;
     /* The film's own scroll, which is the document minus the tail. Everything
        the film does is a function of THIS, so the tail cannot stretch a single

--- a/src/ptl-page.js
+++ b/src/ptl-page.js
@@ -780,10 +780,12 @@
      distance, and until that line runs there isn't one. A no-op on every engine
      that still has the film fixed — see --film-bleed in the page.
 
-     Guarded like every other reach for PTLField in this file, and for the
-     reason given above mount: the name is undeclared when the script is
-     missing, so touching it at all is a ReferenceError, not a falsy read. */
-  if (typeof PTLField !== 'undefined') {
+     Keyed to the FIELD rather than the namespace, which also settles the
+     undeclared-name problem for free: a truthy field means the script is
+     there. mount() returns null when there is no WebGL2 or the program will
+     not build, and unfixing the stage then buys a composited layer, a scroll
+     animation and a taller buffer to carry nothing at all. */
+  if (field) {
     PTLField.pin(document.querySelector('.stage'));
   }
   let raf = 0, shown = -1, remeasure = false, lastW = innerWidth;

--- a/src/ptl-page.js
+++ b/src/ptl-page.js
@@ -776,6 +776,16 @@
   }
   document.body.classList.remove('no-js');
   document.body.style.height = ((S.length * PER + TAIL) * 100) + 'vh';
+  /* After the height, never before: pin measures the document's scrollable
+     distance, and until that line runs there isn't one. A no-op on every engine
+     that still has the film fixed — see --film-bleed in the page.
+
+     Guarded like every other reach for PTLField in this file, and for the
+     reason given above mount: the name is undeclared when the script is
+     missing, so touching it at all is a ReferenceError, not a falsy read. */
+  const followFilm = typeof PTLField !== 'undefined'
+    ? PTLField.pin(document.querySelector('.stage'))
+    : () => {};
   let raf = 0, shown = -1, remeasure = false, lastW = innerWidth;
   let endU = -1;                          // last published --ending
   let resU = '';                          // last published --resolved
@@ -791,6 +801,11 @@
   let still = false;
 
   function render() {
+    /* Here rather than in frame(), because this is the one place that draws:
+       the ambient loop reaches it too, and during a scroll with ambient
+       running frame() is skipped entirely. A drawn film that did not move
+       with the page would be worse than either. */
+    followFilm();
     const max  = document.documentElement.scrollHeight - innerHeight;
     /* The film's own scroll, which is the document minus the tail. Everything
        the film does is a function of THIS, so the tail cannot stretch a single


### PR DESCRIPTION
## Corrected diagnosis

The first attempt guessed *clipping* and was wrong. The deploy preview showed it: the bottom bar turned **white**, which is worse than the black it replaced.

**The film is not clipped — it is covered.** Safari 26 tints its own chrome from the page instead of letting the page paint there: it looks for a `position: fixed` element against each viewport edge and takes that element's `background-color`. The top bar has been reading the page's black all along, which is why only the bottom ever looked wrong.

The first attempt put an opacity on **both** full-screen fixed layers. `.type` is the topmost one at that edge, and it has to stay transparent for the film to show through — so all it could offer Safari was a transparent layer, which is read as *light*, and answered with white.

## Now

```css
@supports (-webkit-touch-callout: none) {
  .stage {
    background: var(--paper);
    opacity: 0.999;
  }
}
```

Only the film's own layer carries it, and it carries the ground as a real `background-color` for Safari to read. It sits **behind an opaque canvas**, so nothing on the page can see it. The opacity stays a thousandth off 1 — that is what keeps Safari from treating a full-screen fixed layer as a plain fill. `.type` is deliberately in neither rule.

`about.html` gets the same on `#c`; its `.veil` is left alone for the same reason `.type` is.

## Verified here

- Inert outside iOS — computed `.stage` is `opacity: 1 / rgba(0,0,0,0)` as served in both local engines.
- Forcing the rule on changes **no pixel by more than the film's own breathing between two frames** (max delta 24/255 across 1.2% of pixels, which is the ambient clock, not the rule — a background behind an opaque canvas cannot paint).
- `pnpm verify` clean.

## What to look for

Bottom bar should read **black like the top one**, not white. If it is still white, the next lever is the page's `color-scheme`/`theme-color` pair rather than the layer, and I would want to try one at a time again.

What this cannot do is make the bar show the film. Safari decides what goes in its own chrome; the best it will take from us is a colour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes the procedural film from a fixed viewport layer into an iOS-targeted, scroll-carried layer with extra canvas bleed so Safari’s bottom chrome can sample the page ground consistently.
- Adds guarded scroll-timeline positioning and bleed containment on the landing and about pages.
- Extends the WebGL renderer with explicit frame-origin geometry so the visible composition remains stable inside the taller buffer.
- Publishes and refreshes the film’s document travel distance only after a renderer mounts successfully.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| about.html | Adds overflow containment, guarded film pinning CSS, and renderer pin initialization for the naturally sized about page. |
| index.html | Adds the guarded absolute film layer, bleed layout, and scroll-timeline animation for supported iOS WebKit environments. |
| src/ptl-field.js | Separates visible frame geometry from the bleed buffer and adds document-travel publication for pinned film layers. |
| src/ptl-page.js | Pins the landing-page stage after body sizing and only when the WebGL field mounted successfully. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[PTLField mounts successfully] --> B[PTLField.pin sets data-film-pinned]
  B --> C{Safari-related feature guard matches}
  C -- No --> D[Film remains fixed]
  C -- Yes --> E[Film becomes absolute with 144px bleed]
  E --> F[Renderer separates visible frame from bleed using uOrigin]
  F --> G[Scroll timeline translates film by --film-travel]
  G --> H[Film follows document while painting beneath bottom chrome]
```

<sub>Reviews (7): Last reviewed commit: ["Stop the carried film lengthening the ab..."](https://github.com/predictive-text-labs/ptl-landing/commit/4d5fe0d89fa10f7ae5697b4e2e9df0d60e913274) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51822636)</sub>

<!-- /greptile_comment -->