### PR TITLE
Run one line through every headline

### DIFF
--- a/src/ptl-page.js
+++ b/src/ptl-page.js
@@ -389,7 +389,53 @@
        it also cannot exceed 3.75% of the height — the button has to fit under
        the claim without the pair being crushed. */
     ctaGap = Math.min(FIN.CTA_GAP * rem, innerHeight * 0.0375);
+    alignHeads();
   };
+
+  /* ONE LINE THROUGH EVERY HEADLINE.
+     ------------------------------------------------------------------------
+     The blocks are bottom-anchored, which aligns them by the bottom of
+     whatever each one contains. That is not what the eye reads: a two-line
+     headline and a three-line headline with a sub-line under it share an edge
+     nobody can see, and their words sit 107px apart down the frame. The beat
+     that reaches highest looks placed and the rest look like they slipped.
+
+     So the shared thing is the HEADLINE'S CENTRE, and the line is not a number
+     — it is wherever the deepest beat already puts it. Every other beat rises
+     to meet that one; nothing is ever pushed down, and the beat with the most
+     in it does not move at all. Re-derived on every measure, so a re-wrap at a
+     new width moves the line rather than stranding it.
+
+     The sub-line is deliberately outside the centring. It hangs below the
+     headline as it always did; centring the whole block instead would drop the
+     one beat that has one by half its height and break the line it defines.
+
+     Phones keep their own rule — the copy is centred in the frame there by the
+     stylesheet, so this hands the elements back and stays out of it. */
+  const inkCentre = (el) => {
+    const cs = getComputedStyle(el);
+    const pt = parseFloat(cs.paddingTop) || 0;
+    const pb = parseFloat(cs.paddingBottom) || 0;
+    return el.offsetTop + pt + (el.offsetHeight - pt - pb) / 2;
+  };
+  const alignHeads = () => {
+    const heads = blocks.filter(b => b.head);
+    for (const b of heads) { b.el.style.top = ''; b.el.style.bottom = ''; }
+    if (phone) return;
+    const box = copy.clientHeight;
+    const at = heads.map(b => ({ b, h: b.el.offsetHeight, y: inkCentre(b.head) }));
+    const line = Math.min(...at.map(a => box - a.h + a.y));
+    for (const a of at) {
+      a.b.el.style.top = `${(line - a.y).toFixed(1)}px`;
+      a.b.el.style.bottom = 'auto';
+    }
+  };
+  /* The faces are font-display:block, so the first measure can land on
+     fallback metrics and the line would be derived from a headline that is
+     about to change height. Nothing else here is that sensitive to it — the
+     old bottom anchor did not care what the block measured — so this re-derives
+     the line alone rather than forcing a whole remeasure. */
+  if (document.fonts && document.fonts.ready) document.fonts.ready.then(alignHeads);
 
   /* The shader's own normalisation, in JS. baseOf() in ptl-field.js is the
      original; this is the only other copy and both are written from CLOSE, so


### PR DESCRIPTION
## What was wrong

The copy blocks are **bottom-anchored** — `.blk { bottom: 0 }` inside `.copy` — so they align by the bottom of whatever each one contains. Nobody reads that edge. Measured at 1600×960:

| beat | lines | sub-line | headline centre |
|---|---|---|---|
| In twenty years… | 3 | no | 802 |
| The question is not… | 2 | no | 831 |
| How can we help… | 2 | no | 831 |
| **A machine earns…** | 3 | **yes** | **724** |
| Predictive Text Labs… | 3 | no | 802 |

107px apart. The beat with the most in it looked placed; the rest looked like they had slipped.

## The mechanism

Align by the **headline's centre**, and take the line from the beat that already reaches highest — no named beat, no constant:

```js
const line = Math.min(...at.map(a => box - a.h + a.y));   // where the deepest beat already puts it
```

Every other beat rises to meet it, nothing is ever pushed down, and **the beat that defines the line does not move at all** — so the frame you were happy with is untouched. Re-derived on every `measure()`, so a re-wrap at a new width moves the line rather than stranding it.

The sub-line stays outside the centring — it hangs below the headline as before. Centring the whole *block* instead would drop COMMIT by half its sub-line and break the line it defines.

## Verified

- **Spread across the five beats:** 0.3px at 1600×960 and 2000×1200, 0.0px at 1280×800 — against 107px before.
- **Phones untouched.** The stylesheet centres the copy in the frame there; `alignHeads` hands the elements back and returns. Measured phone layout is byte-for-byte the old one.
- **The beats that rose are on no worse ground.** Same legibility gate over the whole story, branch vs HEAD: worst contrast under a glyph is identical (1.06:1 in both, at the resolve — where the ink inverts, so the absolute number there is a gate artifact, not a finding), and one sample improves, 2.5 → 3.4.
- Re-derived once on `document.fonts.ready`: the faces are `font-display: block`, so the first measure can land on fallback metrics. The old bottom anchor did not care what a block measured; this does.
- `pnpm verify` clean.

Preview: https://deploy-preview-14--ptl-landing.netlify.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces bottom-aligned copy blocks with dynamically calculated headline-center alignment while preserving the existing phone layout.
- Recomputes the common headline line during layout measurement and after fonts load.
- Excludes sub-lines from headline centering so they continue to hang below their associated headline.
- Clears desktop inline positioning when the phone breakpoint is active.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The new alignment runs after its dependencies are initialized, uses layout-preserving measurements, recalculates after font and viewport changes, and restores stylesheet-controlled positioning on phones.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/ptl-page.js | Adds responsive headline-center alignment using existing block geometry, with font-load remeasurement and a phone-layout escape path; no actionable defect was found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Run one line through every headline"](https://github.com/predictive-text-labs/ptl-landing/commit/fe4c5383bf79eb08a04ce01f25a86968f80d3d5e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51835371)</sub>

<!-- /greptile_comment -->