### PR TITLE
Collapse to variation 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,60 +54,23 @@ crawler, a link preview and a screen reader with a page containing no words at
 all. So the argument lives in `#story` as ordinary semantic HTML and the script
 reads it out of the DOM. One source of truth. Edit the copy there.
 
-## Variations
+## The palette
 
-Four colourways: variation 1 is the default and has no query at all, and 2, 3
-and 4 are selected with a query parameter. `?v=` anything else is variation 1.
-
-    /               1  a toned film on black: the mark's hue ramps with its
-                       brightness, it casts a drop shadow, and the ground
-                       carries a little of the same warmth — all three drain
-                       away together, leaving white on hard black by the last
-                       frame
-    /?v=2           2  inverted onto stone-300, the old site's own warm paper
-    /?v=3           3  variation 4's contract on paper: the same strictly
-                       one-bit film, a redder step of stock — taupe-300 —
-                       and the same black type, with the blue confined to
-                       the FILM and resolving to black as the mark closes
-    /?v=4           4  the control: white mark on black, strictly one bit.
-                       No shadow, no hue ramp, no bloom, no feathered edge —
-                       every pixel is either the ink or the paper
-
-Variation 4 is not a colourway so much as the thing the others are arguing
-against. Variation 1 claims the field reads as an emulsion catching light
-rather than as a diagram; that claim is only worth something next to the
-version with none of it, which is what 4 is. Two switches carry the whole
-difference — `shadow` and `tone` in the draw options — so the two can be
-compared without a second renderer. Variation 3 takes `tone` off as well: it
-is 4's contract with a colour in it.
-
-A third switch, `print`, is not a variation at all: it is what the toning
-MEANS on a light ground. On black the ground is zero, so everything added to
-it reads as light — a warm haze off the form, weighted toward the floor of the
-frame like a lamp below the picture. On paper the ground is the brightest
-thing in frame, so the same haze reads as dirt, and the same lamp puts its
-heaviest smudge exactly where the arch's legs are thinnest. The pale variants
-therefore get the print reading of those terms: the ground's haze becomes a
-straight vertical wash instead of a halo keyed to the form, it drops from half
-the tint to a few percent — dot gain instead of glow — and the tone response
-gets a contrast curve, because a printed stroke has a boundary where a lit one
-has a falloff. What is left is one gradient, running up the frame. It is
-derived from the paper's own luminance rather than named per variation, so a
-palette that inverts the ground gets it without having to remember to ask.
-
-Variation 3 is the same 1-bit contract as variation 4, on paper instead of on
-black, and keeping one thing: the mark's colour travels from `--field` to
-`--field-end` across the closing window, so the film is blue for the whole
-argument and neutral by the time the mark lands. The drain sits after the tone
-switch in the shader, which is why turning the toning off does not take it with
-it. Nothing else survives — no ramp, no haze, no bloom, no feathered edge, and
-no `--tint`, because on this variation nothing can read one.
+One colourway, and no switch: a toned film on black. The mark's hue ramps with
+its brightness, it casts a drop shadow, and the ground carries a little of the
+same warmth — all three drain away together, leaving white on hard black by the
+last frame.
 
 Every colour, including the two the shader resolves its 1-bit output to, comes
-from the `:root` blocks at the top of `index.html`; the renderer is handed
-`--field` and `--paper` at draw time, so the film and the type cannot disagree
-about the ground they are on. Once one is chosen, the other three blocks and
-the switch come out.
+from the `:root` block at the top of `index.html`, which is the source;
+`about.html` mirrors it. The renderer is handed `--field` and `--paper` at draw
+time, so the film and the type cannot disagree about the ground they are on.
+
+Three further colourways once shipped, selected with a `?v=` query parameter —
+two on warm paper and one strictly-one-bit control on black. They are gone, and
+with them the `shadow`, `tone` and `print` draw options that carried the
+difference. Git is the archive: they are preserved at the tag
+`variants-2-3-4`.
 
 ## Develop
 

--- a/about.html
+++ b/about.html
@@ -880,16 +880,10 @@
         const gainAt = (p) =>
           lerp(1.0, 0.1, Math.pow(clamp((p - 0.18) / 0.82), 0.55));
 
-        /* The ambient clock, as on the film: real time, sped up by scroll speed,
-     reaching ONLY the size of the halftone marks. It cannot move the
-     composition, because nothing positional reads it. */
-        const AMB_IDLE = 1.0,
-          AMB_GAIN = 5.5,
-          AMB_DECAY = 0.86;
-        let clock = 0,
-          lastTs = 0,
-          vel = 0,
-          lastY = window.scrollY;
+        /* The ambient clock — real time, sped up by scroll speed, reaching ONLY
+     the size of the halftone marks — is the FIELD's, and it keeps it. This page
+     had a second copy of the arithmetic, identical to ptl-page.js's down to the
+     constants and the two bug fixes in it. What is left here is the pump. */
         let ticking = 0;
 
         function render() {
@@ -911,7 +905,6 @@
             ink2: INK2,
             paper: PAPER,
             tint: TINT,
-            time: clock,
             amb: reduce ? 0 : 1,
           });
         }
@@ -920,17 +913,7 @@
           if (ticking) return;
           ticking = requestAnimationFrame(function step(ts) {
             ticking = 0;
-            /* A gap past 0.5s is a returning tab; anything else is a slow frame
-     and counts for what it was. Same clamp as ptl-page.js. */
-            const raw = lastTs ? (ts - lastTs) / 1000 : 0.016;
-            const dt = raw > 0.5 ? 0.016 : Math.min(raw, 0.25);
-            lastTs = ts;
-            if (!reduce) {
-              /* Per second, not per frame: AMB_DECAY is tuned at 60Hz, so per
-     frame the boost bled off twice as fast at 120Hz. */
-              vel *= Math.pow(AMB_DECAY, dt * 60);
-              clock += dt * (AMB_IDLE + AMB_GAIN * Math.min(vel, 1.4));
-            }
+            if (field) field.frame(ts, !reduce);
             render();
             /* Only while there is something to draw on: with no renderer, or one
      that died with its context, this held the compositor open at 60fps to
@@ -943,8 +926,7 @@
         addEventListener(
           "scroll",
           () => {
-            vel += Math.abs(window.scrollY - lastY) / Math.max(innerHeight, 1);
-            lastY = window.scrollY;
+            if (field) field.scrolled();
             if (reduce) render();
             else tick();
           },
@@ -958,7 +940,7 @@
         });
         document.addEventListener("visibilitychange", () => {
           if (document.hidden) return;
-          lastTs = 0;
+          if (field) field.idle();
           tick();
         });
 

--- a/about.html
+++ b/about.html
@@ -68,12 +68,10 @@
         font-weight: 100 900;
         font-display: block;
       }
-      /* Named by .backers, and until now not defined on this page — so the one
-     row of small caps that asks for Inter was falling out of the stack to
-     system-ui, the only system face on a page that is otherwise entirely
-     local. Not preloaded: a reader arriving the way this page is meant to be
-     arrived at came off `join us` in the film's closing lockup, which is set
-     in Inter, so it is already in cache. */
+      /* .backers asks for Inter; without this its row of small caps fell out of
+     the stack to system-ui, the only non-local face on the page. Not
+     preloaded — the reader arrives off `join us`, which is set in Inter and
+     already cached. */
       @font-face {
         font-family: Inter;
         src: url("/fonts/Inter.woff2") format("woff2");
@@ -121,19 +119,11 @@
         color: var(--paper);
       }
 
-      /* THE FILM, CONTINUED.
-     ------------------------------------------------------------------------
-     The same shader as the front page, on the same scroll clock. This is the
-     entire reason the page reads as the same site rather than a document that
-     happens to share a palette — not the fonts, not the tokens, not the
-     chrome. Those are agreement about details; this is the same object.
-
-     And it runs the film BACKWARDS first. The front page closes: a wide arch
-     collapsing to one small mark under MACHINES THAT DECIDE. Arriving here,
-     the mark is exactly where that page left it, and scrolling OPENS it again
-     — the argument that ended is being reopened — before closing it a second
-     time under `join us`, so the one action on this page sits beneath the
-     same closed mark as the one action on the front page. */
+      /* THE FILM, CONTINUED. The same shader as the front page, on the same
+     scroll clock — that, and not the fonts or the tokens, is what makes this
+     read as the same site rather than a document sharing a palette. And it
+     runs BACKWARDS: the mark starts exactly where the film left it, closed,
+     and scrolling opens it again. */
       #c {
         position: fixed;
         inset: 0;
@@ -143,18 +133,15 @@
         display: block;
         pointer-events: none;
       }
-      /* The defocus veil: a translucent sheet of the page's own ground over a
-     plain blur, saturate(0) so the blurred field cannot tint the paper.
+      /* The defocus veil: a sheet of the page's own ground over a plain blur,
+     saturate(0) so the blurred field cannot tint the paper.
 
-     MASKED TO THE LEFT, which is the whole trick. Laid flat across the
-     viewport it does not calm the field, it ERASES it — blur(30) plus a .72
-     sheet turns the halftone into a grey smudge and the page loses the one
-     thing that makes it this site. The type is flush left, so the veil is
-     too: the left of the frame is a calm ground to read on, the right is the
-     film at full strength, and the mask crossfades between them over a third
-     of the screen so there is no visible edge. The solid part has to clear
-     the intro's measure, which now runs to the middle of the frame. Masking the layer takes the
-     backdrop-filter with it, which a gradient background alone cannot do. */
+     MASKED TO THE LEFT, which is the trick — laid flat it does not calm the
+     field, it ERASES it. The type is flush left, so the veil is too: calm
+     ground under the copy, film at full strength to its right, crossfaded over
+     a third of the screen so there is no visible edge. The solid part has to
+     clear the intro's measure. Masking the LAYER is what carries the
+     backdrop-filter with it; a gradient background alone cannot. */
       .veil {
         position: fixed;
         inset: 0;
@@ -260,9 +247,8 @@
           padding: 1.5rem 1.2rem;
           padding-left: max(1.2rem, env(safe-area-inset-left));
           padding-right: max(1.2rem, env(safe-area-inset-right));
-          /* The shorthand above wipes the base rule's safe-area padding-top, and
-         the page declares viewport-fit=cover — without this the wordmark lays
-         itself into a notch. Same value as index.html. */
+          /* The shorthand above wipes the base rule's safe-area padding-top,
+         and viewport-fit=cover would then lay the wordmark into a notch. */
           padding-top: max(1.5rem, env(safe-area-inset-top));
         }
         .nav i {
@@ -292,17 +278,10 @@
         }
       }
 
-      /* THE BEATS.
-     ------------------------------------------------------------------------
-     The front page is not a page with sections; it is a sequence of frames
-     you scroll through, one statement at a time. Neither is this. Each beat
-     takes the height of the screen and holds ONE thought at display size, and
-     the scale climbs as the argument does — the reader is being carried
-     somewhere, and if the type does not climb with them it is just a wall of
-     small text with generous margins, which is what this page was.
-
-     No section headers. Five mono labels cut it into a brochure with five
-     chapters; the vertical space and the change of scale ARE the structure. */
+      /* THE BEATS. Frames, not sections: each takes the height of the screen and
+     holds ONE thought at display size, and the scale climbs as the argument
+     does. No section headers — the vertical space and the change of scale ARE
+     the structure, where five mono labels would make it a brochure. */
       .beat {
         min-height: 100vh;
         display: flex;
@@ -348,15 +327,11 @@
         font-style: normal;
       }
 
-      /* PEOPLE — names at a size you could read across a room, because on this
-     page the names are the credential. */
-      /* THREE COLUMNS AND TWO ROWS, BUT NOT THE FULL WRAP. Across the whole
-     88rem the third column landed out at the right edge of the screen,
-     past where anything else on the page reaches and out over the mark.
-     The bios are capped at 24rem whatever the grid does, so the width was
-     buying distance rather than words. Capped here, the six of them keep
-     their two rows and the block sits inside the same column the writing
-     above it does. */
+      /* PEOPLE — names at a size you could read across a room, because here the
+     names are the credential. Three columns, but capped short of the full
+     88rem: the bios cap at 24rem whatever the grid does, so the extra width
+     bought distance rather than words and pushed the third column out over the
+     mark. */
       .people {
         list-style: none;
         display: grid;
@@ -375,10 +350,9 @@
           gap: 2rem;
         }
       }
-      /* The names are set at the intro's size, not above it. Two Cormorant sizes
-     a few points apart in one frame reads as an accident rather than a
-     hierarchy; at the same size the paragraph and the names are one voice and
-     the mono note under each name is the only thing that steps down. */
+      /* At the intro's size, not above it: two Cormorant sizes a few points
+     apart in one frame read as an accident rather than a hierarchy, and the
+     mono note under each name is then the only thing that steps down. */
       .people .nm {
         font:
           300 clamp(1.02rem, 1.32vw, 1.16rem)/1.3 Cormorant,
@@ -397,9 +371,8 @@
         max-width: 24rem;
       }
 
-      /* Set at the intro's size, the same as the names. The backers are a
-     credential, not a headline — at display size they were the largest type
-     on a page whose own ask is smaller than they were. */
+      /* Also at the intro's size. The backers are a credential, not a headline —
+     at display size they were the largest type on the page. */
       .backers {
         list-style: none;
         display: flex;
@@ -445,36 +418,17 @@
         }
       }
 
-      /* JOIN US — set directly under the people, because the answer to "who is
-     us" is the six names above it. The link is the film's closing object at
-     close to the film's own size: Cormorant,
-     lowercase, no rule until the cursor is on it, and at the names' own size
-     — one Cormorant size for the whole section. No arrow, and nothing else
-     scaling it up: directly under six people at 18.6px it is a line you read,
-     not a button, and both the arrow and the larger size made it a button. */
-      /* The intro, which is now the first thing on the page: the reader came off
-     `join us` on the film, so the page opens by answering who "us" is rather
-     than restating the argument they just scrolled through. Cormorant at a
-     reading size — big enough to be the opening statement, small enough to be
-     two paragraphs rather than a headline. */
-      /* A MEASURE, NOT A WIDTH. 84ch rendered about 105 characters to the
-     line — nearly twice a comfortable one, and on a wide screen the second
-     line of each paragraph ran out past everything else on the page.
+      /* The intro is the first thing on the page: the reader came off `join us`
+     on the film, so it opens by answering who "us" is rather than restating
+     the argument they just scrolled through.
 
-     IN REM, THOUGH, AND THAT IS A CORRECTION. This was 54ch, on the reasoning
-     that ch is set in the text's own font and so holds if the type ever
-     changes size. It is not: ch resolves against THIS element's font, and
-     nothing gives the container one, so it was measuring the browser's
-     default serif — Times, 16px, a face that appears nowhere on this page —
-     while the paragraphs inside it are Cormorant at 18.56px. The measure was
-     therefore both wrong about itself and at the mercy of whatever the
-     visitor's system serves as `serif`, which is a strange thing for a fixed
-     line count to depend on. 29rem is the same 464px here, on every machine.
-
-     464px because the first paragraph breaks to four lines above 448 and the
-     fourth is two words. Measured across chromium, webkit and firefox: the
-     break is at exactly 448px in all three, so this carries 16px of slack
-     rather than sitting on the threshold. */
+     A MEASURE, NOT A WIDTH — and in rem, not ch. ch resolves against THIS
+     element's font, which nothing here sets, so it was measuring the browser's
+     default serif while the paragraphs inside are Cormorant at 18.56px. 29rem
+     is the same 464px on every machine, and 464 because the first paragraph
+     breaks to four lines — the fourth two words — above 448px in chromium,
+     webkit and firefox alike, so this carries 16px of slack rather than
+     sitting on the threshold. */
       .intro {
         max-width: 29rem;
         margin-bottom: 4.4rem;
@@ -498,8 +452,7 @@
 
       /* THE PRINCIPLES — twelve, so a table and not twelve cards. The only part
      of the page that is scanned rather than read, and last on purpose: a
-     reader still here has already decided they are interested, and now wants
-     to know what the days are like. */
+     reader still here wants to know what the days are like. */
       #principles {
         padding: 7rem 0 5rem;
       }
@@ -508,14 +461,10 @@
           padding: 4.6rem 0 3.4rem;
         }
       }
-      /* The last thing on the page, so it does not get a whole frame of its own —
-     a frame with four names in it and nothing after would read as the page
-     having failed to load the rest. */
-      /* THE ASK OWNS THE FRAME. min-height, not height: the line wraps on a
-     phone and a fixed height would clip it. svh rather than vh so the bar
-     appearing on a phone cannot push the line out of view — this section is
-     one short line with nothing under it, which is the one case where the
-     small viewport is the honest one. */
+      /* THE ASK OWNS A VIEWPORT: one line, nothing else in frame, so there is no
+     second thing to read at the moment the reader decides. min-height, not
+     height — the line wraps on a phone and a fixed height would clip it; svh
+     rather than vh so a bar appearing cannot push it out of view. */
       .ask {
         min-height: 100svh;
         text-align: center;
@@ -523,16 +472,14 @@
         display: grid;
         align-content: center;
       }
-      /* PINNED TO THE CIRCLE, NOT TO THE SECTION. The canvas is fixed to the
-     viewport, so the ring never moves with scroll — centring the line in its
-     own section only lands it in the ring at the one scroll offset where the
-     two happen to coincide, and the footer below guarantees that offset is
-     never reached. Sticky holds it at the ring's own height for as long as
-     the section is in frame.
+      /* PINNED TO THE CIRCLE, NOT TO THE SECTION. The canvas is fixed, so the
+     ring never moves with scroll: centring the line in its own section lands
+     it in the ring only at the offset where the two coincide, which the footer
+     guarantees is never reached. Sticky holds it at the ring's own height.
 
-     The height is the shader's, not a guess: form() puts the circle at uv
-     (0, 0.02) once g has settled, uv.y runs up from the viewport's middle,
-     and the normalisation is max(height, width / 1.78) — 56.18vw. */
+     That height is the shader's, not a guess: form() puts the circle at uv
+     (0, 0.02) once g has settled, uv.y runs up from the viewport's middle, and
+     the normalisation is max(height, width / 1.78) — 56.18vw. */
       .ask-w {
         position: sticky;
         top: calc(50svh - 0.02 * max(100svh, 56.18vw));
@@ -573,11 +520,9 @@
         }
       }
 
-      /* Centred, and the rule is gone: it was a left-aligned caption's hinge, and
-     a hinge on a centred line reads as a stray mark. */
-      /* Sits LOW. 6rem of air under the last line left the block floating in the
-     middle of the closing frame with a dead band beneath it; a colophon reads
-     as a colophon when it is near the edge it is printed against. */
+      /* Sits LOW: a colophon reads as one when it is near the edge it is printed
+     against, and 6rem of air under it left the block floating. Centred, and
+     with no hinge rule — a hinge on a centred line reads as a stray mark. */
       .closing {
         padding: 0 0 3rem;
         text-align: center;
@@ -644,21 +589,19 @@
         text-wrap: pretty;
       }
       /* The attribution runs on from the quote rather than under it: on its own
-     line, tracked and uppercased, it read as a third register in a cell that
-     only has room for two. Inline and in the body's own face, it is what it
-     is — the end of the sentence. */
+     line, tracked and uppercased, it read as a third register in a cell with
+     room for two. */
       .prin cite {
         font-style: normal;
         color: var(--dim);
         white-space: nowrap;
       }
 
-      /* ARRIVAL — each beat resolves as it comes up the screen, the way the
-     film's copy resolves out of the field. Opacity and a small rise only: the
-     film's mask wipe belongs to type emerging FROM the halftone, and pasted
-     onto a scrolling document it would read as an effect rather than as the
-     same object. `.fx` is added by script and only when motion is allowed, so
-     with JS off or motion reduced every word is simply present. */
+      /* ARRIVAL — each beat resolves as it comes up the screen. Opacity and a
+     small rise only: the film's mask wipe belongs to type emerging FROM the
+     halftone, and on a scrolling document it reads as an effect instead.
+     `.fx` is added by script and only when motion is allowed, so with JS off
+     or motion reduced every word is simply present. */
       .fx .up {
         opacity: 0;
         transform: translateY(1.4rem);
@@ -689,13 +632,10 @@
       </header>
 
       <main class="wrap">
-        <!-- The page's only h1. Every visible heading here is either a name or
-           a principle, so without this the document had no heading at all and
-           the twelve h3s hung off nothing. -->
+        <!-- The page's only h1: every visible heading here is a name or a
+           principle, so without this the twelve h2s hang off nothing. -->
         <h1 class="sr">About Predictive Text Labs</h1>
 
-        <!-- The notes are placeholders and say so, so a half-filled page cannot
-           be mistaken for a finished one. -->
         <section class="beat" aria-label="Team">
           <div>
             <div class="intro up">
@@ -817,9 +757,6 @@
           </ol>
         </section>
 
-        <!-- The ask owns a viewport of its own, the way the lockup does on the
-           front page: one line, nothing else in frame, so there is no second
-           thing to read at the moment the reader decides. -->
         <section class="ask" aria-label="Get in touch">
           <div class="ask-w">
             <a
@@ -866,8 +803,7 @@
         let reduce = reduceMQ.matches;
 
         /* The renderer's palette, read out of the stylesheet rather than
-     restated here: index.html's :root is the source, this page mirrors it, and
-     the film is handed whatever the browser resolved. */
+     restated here: index.html's :root is the source and this page mirrors it. */
         const hex3 = (h) => {
           const n = (h || "").trim().replace("#", "");
           return [0, 2, 4].map((i) => parseInt(n.slice(i, i + 2), 16) / 255);
@@ -876,8 +812,7 @@
           INK2 = [1, 1, 1],
           PAPER = [0, 0, 0],
           TINT = [0, 0, 0];
-        /* Declared here, not beside resolveAt below: palette() runs before that
-     block is reached, and a `let` read from above its own line throws. */
+        /* Outside the block below, which only assigns them. */
         let TYPE_A = "#ffffff",
           TYPE_B = "#ffffff";
         {
@@ -886,33 +821,27 @@
           INK2 = hex3(cs.getPropertyValue("--field-end"));
           TINT = hex3(cs.getPropertyValue("--tint"));
           PAPER = hex3(cs.getPropertyValue("--paper"));
-          /* Read from the ROOT rule, never from the element we write --ink-live
-       onto — reading back our own output would ratchet the type toward its
-       target a frame at a time and never return. */
+          /* From the ROOT rule, never the element we write --ink-live onto:
+       reading our own output back would ratchet the type toward its target a
+       frame at a time and never return. */
           TYPE_A = (cs.getPropertyValue("--ink") || "#ffffff").trim();
           TYPE_B = (cs.getPropertyValue("--field-end") || TYPE_A).trim();
         }
 
         /* `typeof`, not truthiness: on a failed load PTLField is an undeclared
-     name, so `PTLField && …` throws a ReferenceError rather than
-     short-circuiting. A null field is not a failure worth reacting to — the
-     page is a complete document without it. */
+     name, so `PTLField && …` throws rather than short-circuiting. A null field
+     is not a failure — the page is a complete document without it. */
         const field =
           typeof PTLField !== "undefined"
             ? PTLField.mount(document.getElementById("c"), { mode: "form" })
             : null;
 
         /* OPEN is where the mark sits when the reader lands: exactly where the
-     front page left it, closed. Scrolling opens it back out to WIDE and it
-     STAYS there.
-
-     It used to close again at the bottom, mirroring the film. That was right
-     when this page was nine screens of argument and wrong now it is two and a
-     half of names: a closing mark is a small dense object in the middle of
-     the frame, and the middle of the frame is where the second column of the
-     team grid lives — it parked itself on top of Alex Pan. Wide, the arch is
-     a ground rather than an object, and nothing it overlaps is anything but
-     texture. */
+     front page left it, closed. Scrolling opens it out to WIDE and it STAYS
+     there. It used to close again at the bottom, mirroring the film — but a
+     closing mark is a small dense object in the middle of the frame, which is
+     where the team grid's second column lives, and it parked itself on a name.
+     Wide, the arch is a ground and overlaps nothing but texture. */
         const OPEN = 0.94,
           WIDE = 0.3,
           OPENS_BY = 1.0;
@@ -924,11 +853,9 @@
         const lerp = (a, b, t) => a + (b - a) * t;
 
         /* Mostly linear, with only a soft start. A pure smoothstep flattens at
-     BOTH ends, so the last fifth of the page moved the arch by 0.04 and the
-     bottom of the document read as frozen — measured 0.20 mean pixel change
-     across the final stretch against 10.6 mid-page. Blended two thirds
-     toward linear it keeps a constant rate all the way down and still eases
-     off the top. */
+     BOTH ends, so the last fifth of the page read as frozen — 0.20 mean pixel
+     change against 10.6 mid-page. Two thirds toward linear holds a constant
+     rate all the way down and still eases off the top. */
         const gAt = (p) =>
           lerp(
             OPEN,
@@ -937,13 +864,11 @@
           );
 
         /* THIS PAGE KEEPS ITS OWN RESOLVE WINDOW, and has to. gAt runs the film
-     BACKWARDS — g falls from 0.94 to 0.30 as you scroll — where ptl-page.js's
-     clock runs up, so its window (welded to six beats this page does not have)
-     lands here as white and unshadowed for the top fifth: measured, the marks
-     went from R-B +64.7 to -2.8 a quarter of the way down. There is no shared
-     setting right for both. Eased IN, over the stretch the field actually
-     occupies, which leaves the duotone intact and lets it resolve as the field
-     recedes behind the document. */
+     BACKWARDS — g falls from 0.94 to 0.30 — where ptl-page.js's clock runs up,
+     so its window lands here as white and unshadowed for the top fifth: the
+     marks went from R-B +64.7 to -2.8 a quarter of the way down. No shared
+     setting is right for both. Eased IN, over the stretch the field actually
+     occupies, so the duotone survives and resolves as the field recedes. */
         const RES_A = 0.55,
           RES_B = 0.985;
         const resolveAt = (g) =>
@@ -956,34 +881,23 @@
         };
 
         /* And it RECEDES as the page stops being a film and becomes a document.
-     The principles are a full-width table of twelve cells; there is no right
-     half to give the field, and at full strength the arch's descending limb
-     wrote itself straight through "Dream in ripples" and "Come with
-     solutions". Gain is the honest control for this — it takes the marks down
-     in size rather than fading a layer over the top, so what is left is the
-     same field, quieter, instead of the same field behind gauze.
+     The principles are a full-width table; there is no right half to give the
+     field, and at full strength the arch's descending limb wrote itself
+     through the cells. Gain is the honest control — it takes the marks down in
+     SIZE rather than fading a layer over the top, so what is left is the same
+     field, quieter, instead of the same field behind gauze.
 
-     BOTH TRACKS NOW RUN TO THE BOTTOM. They used to finish at 0.45 and 0.60
-     of the scroll, so from three fifths of the way down the field was a
-     still image and the rest of the page scrolled past a frozen picture —
-     which is exactly where it stopped looking alive. Stretched, everything
-     is the same shape, just slower, and the arch is still opening on the
-     last screen. smoothstep's own slope goes to zero at the end, so it
-     arrives rather than stopping dead. */
-        /* A power curve, not a smoothstep, and it runs the whole page. The two
-     requirements pull opposite ways: the field has to be quiet by the time
-     the principles table arrives, and it has to still be MOVING at the
-     bottom. A smoothstep cannot do both — it flattens at the end, so it was
-     already at its floor two thirds down. An exponent under one falls
-     steeply first and then trails, so it is at 0.42 over the principles,
-     which is where the smoothstep put it, and still descending 0.19 -> 0.10
-     across the last screen. */
+     A power curve, not a smoothstep, and it runs the whole page: the field has
+     to be quiet by the time the principles arrive AND still be MOVING at the
+     bottom. A smoothstep flattens at the end and sat on its floor two thirds
+     down; an exponent under one is at 0.42 over the principles and still
+     descending 0.19 -> 0.10 across the last screen. */
         const gainAt = (p) =>
           lerp(1.0, 0.1, Math.pow(clamp((p - 0.18) / 0.82), 0.55));
 
-        /* The ambient clock, as on the film: a real-time clock that reaches ONLY
-     the size of the halftone marks, sped up by how fast the reader scrolls.
-     It cannot move the composition, because nothing positional reads it. */
+        /* The ambient clock, as on the film: real time, sped up by scroll speed,
+     reaching ONLY the size of the halftone marks. It cannot move the
+     composition, because nothing positional reads it. */
         const AMB_IDLE = 1.0,
           AMB_GAIN = 5.5,
           AMB_DECAY = 0.86;
@@ -1023,23 +937,22 @@
           if (ticking) return;
           ticking = requestAnimationFrame(function step(ts) {
             ticking = 0;
-            /* Only a gap past 0.5s is a returning tab; everything else is a slow
-     frame and counts for what it was. Same clamp as ptl-page.js. */
+            /* A gap past 0.5s is a returning tab; anything else is a slow frame
+     and counts for what it was. Same clamp as ptl-page.js. */
             const raw = lastTs ? (ts - lastTs) / 1000 : 0.016;
             const dt = raw > 0.5 ? 0.016 : Math.min(raw, 0.25);
             lastTs = ts;
             if (!reduce) {
-              /* Per second, not per frame: AMB_DECAY is tuned at 60Hz, so once a
+              /* Per second, not per frame: AMB_DECAY is tuned at 60Hz, so per
      frame the boost bled off twice as fast at 120Hz. */
               vel *= Math.pow(AMB_DECAY, dt * 60);
               clock += dt * (AMB_IDLE + AMB_GAIN * Math.min(vel, 1.4));
             }
             render();
-            /* Only while there is something to draw on. The clock reaches
-     exactly one thing — the size of the halftone marks — so with no renderer
-     mounted, or one that died with its context, this was holding the
-     compositor open at 60fps to advance a number nobody reads. render()
-     already returns immediately in both cases; this is the loop agreeing. */
+            /* Only while there is something to draw on: with no renderer, or one
+     that died with its context, this held the compositor open at 60fps to
+     advance a number nobody reads. render() already returns immediately in
+     both cases; this is the loop agreeing. */
             if (field && !field.isDead() && !reduce && !document.hidden) tick();
           });
         }
@@ -1068,8 +981,8 @@
 
         /* ARRIVAL. Added by script only, so a reader with JS off gets the whole
      page at full opacity rather than an empty one. IntersectionObserver
-     because a scroll handler measuring every element is the classic way to
-     make a page like this stutter. */
+     because a scroll handler measuring every element is how a page like this
+     stutters. */
         if (!reduce && "IntersectionObserver" in window) {
           document.body.classList.add("fx");
           const io = new IntersectionObserver(
@@ -1084,16 +997,13 @@
           );
           for (const el of document.querySelectorAll(".up")) io.observe(el);
 
-          /* THE LAST THING ON THE PAGE CANNOT CLEAR A BOTTOM DEAD ZONE.
-       The -10% margin is what stops elements popping in the instant they
-       touch the bottom edge, and it works for everything with page beneath
-       it. The footer has none: on a tall viewport the document simply does
-       not scroll far enough to lift it out of that band, so it sat at
-       opacity 0 forever. Measured at 1728x1080 and 2000x1250 — fully in
-       view at maximum scroll, never revealed; the backers were invisible.
-       Rather than loosen the margin for every element on the page, anything
-       still hidden when the reader actually reaches the bottom is simply
-       shown. */
+          /* THE LAST THING ON THE PAGE CANNOT CLEAR A BOTTOM DEAD ZONE. The
+       -10% margin stops elements popping in the instant they touch the bottom
+       edge, and works for everything with page beneath it. The footer has
+       none: on a tall viewport the document never scrolls far enough to lift
+       it out of that band, so the backers sat at opacity 0 forever (measured
+       at 1728x1080 and 2000x1250). Rather than loosen the margin for every
+       element, anything still hidden at the bottom is simply shown. */
           addEventListener(
             "scroll",
             () => {
@@ -1116,7 +1026,7 @@
           reduce = reduceMQ.matches;
           /* Turning reduce back OFF left the loop dead for the rest of the
      visit: step() self-terminates while reduce is true and nothing else
-     re-arms it, so the field stopped breathing until a reload. */
+     re-arms it. */
           if (was && !reduce) tick();
           if (reduce) {
             document.body.classList.remove("fx");

--- a/about.html
+++ b/about.html
@@ -220,7 +220,9 @@
         gap: 0.9em;
         letter-spacing: 0.24em;
       }
-      .nav i {
+      /* One hairline, two bars — the caption's rule IS the nav's. */
+      .nav i,
+      .cap i {
         width: 2.2em;
         height: 1px;
         background: var(--rule);
@@ -283,15 +285,14 @@
      does. No section headers — the vertical space and the change of scale ARE
      the structure, where five mono labels would make it a brochure. */
       .beat {
+        /* Two declarations, not @supports: an engine without dvh drops the
+       second and keeps the first. The file assumes the unit anyway — .ask
+       pins the page's only CTA with bare svh. */
         min-height: 100vh;
+        min-height: 100dvh;
         display: flex;
         align-items: center;
         padding: 7rem 0;
-      }
-      @supports (height: 100dvh) {
-        .beat {
-          min-height: 100dvh;
-        }
       }
       .beat > div {
         width: 100%;
@@ -320,11 +321,7 @@
         gap: 0.9em;
       }
       .cap i {
-        width: 2.2em;
-        height: 1px;
-        background: var(--rule);
         flex: none;
-        font-style: normal;
       }
 
       /* PEOPLE — names at a size you could read across a room, because here the
@@ -350,10 +347,12 @@
           gap: 2rem;
         }
       }
-      /* At the intro's size, not above it: two Cormorant sizes a few points
-     apart in one frame read as an accident rather than a hierarchy, and the
-     mono note under each name is then the only thing that steps down. */
-      .people .nm {
+      /* At the intro's size, not above it — one rule now, so it cannot drift:
+     two Cormorant sizes a few points apart in one frame read as an accident
+     rather than a hierarchy, and the mono note under each name is then the only
+     thing that steps down. Only the leading differs, set on .intro p below. */
+      .people .nm,
+      .intro p {
         font:
           300 clamp(1.02rem, 1.32vw, 1.16rem)/1.3 Cormorant,
           serif;
@@ -433,12 +432,9 @@
         max-width: 29rem;
         margin-bottom: 4.4rem;
       }
+      /* Longhand after the shorthand above, and later in source, so it wins. */
       .intro p {
-        font:
-          300 clamp(1.02rem, 1.32vw, 1.16rem)/1.72 Cormorant,
-          serif;
-        letter-spacing: 0;
-        color: var(--ink);
+        line-height: 1.72;
         text-wrap: pretty;
       }
       .intro p + p {
@@ -502,8 +498,7 @@
         text-decoration: none;
         padding: 0.12em 0.1em;
       }
-      .ask-a:hover,
-      .ask-a:focus-visible {
+      .ask-a:hover {
         text-decoration: underline;
         text-underline-offset: 0.14em;
         text-decoration-thickness: 1px;
@@ -588,14 +583,6 @@
         color: var(--mid);
         text-wrap: pretty;
       }
-      /* The attribution runs on from the quote rather than under it: on its own
-     line, tracked and uppercased, it read as a third register in a cell with
-     room for two. */
-      .prin cite {
-        font-style: normal;
-        color: var(--dim);
-        white-space: nowrap;
-      }
 
       /* ARRIVAL — each beat resolves as it comes up the screen. Opacity and a
      small rise only: the film's mask wipe belongs to type emerging FROM the
@@ -615,9 +602,6 @@
       }
       .fx .up:nth-child(2) {
         transition-delay: 0.09s;
-      }
-      .fx .up:nth-child(3) {
-        transition-delay: 0.18s;
       }
     </style>
   </head>
@@ -833,7 +817,7 @@
      is not a failure — the page is a complete document without it. */
         const field =
           typeof PTLField !== "undefined"
-            ? PTLField.mount(document.getElementById("c"), { mode: "form" })
+            ? PTLField.mount(document.getElementById("c"))
             : null;
 
         /* OPEN is where the mark sits when the reader lands: exactly where the
@@ -916,12 +900,10 @@
           root.style.setProperty("--ink-live", mixHex(TYPE_A, TYPE_B, res));
           field.draw(p, {
             g: gNow,
-            section: 0,
             resolve: res,
             cell: 12,
             gap: 0.12,
             gain: gainAt(p),
-            fov: 0.7,
             mouse: [0, 0],
             act: 0,
             ink: INK,

--- a/about.html
+++ b/about.html
@@ -81,8 +81,8 @@
         font-display: block;
       }
 
-      /* THE PALETTE — mirrored from index.html, which is the source. The film
-     tokens are here too now, because this page runs the film. */
+      /* THE PALETTE — mirrored from index.html, which is the source and carries
+     the reasoning. Five of these are read at runtime by the script below. */
       :root {
         --paper: #000000;
         --ink: #f4eada;
@@ -90,7 +90,6 @@
         --field-end: #ffffff;
         --dim: #868686;
         --mid: #969696;
-        --soft: #a9a9a9;
         --rule: #353535;
         --wash: rgba(0, 0, 0, 0.62);
         --tint: #c64a16;
@@ -261,6 +260,10 @@
           padding: 1.5rem 1.2rem;
           padding-left: max(1.2rem, env(safe-area-inset-left));
           padding-right: max(1.2rem, env(safe-area-inset-right));
+          /* The shorthand above wipes the base rule's safe-area padding-top, and
+         the page declares viewport-fit=cover — without this the wordmark lays
+         itself into a notch. Same value as index.html. */
+          padding-top: max(1.5rem, env(safe-area-inset-top));
         }
         .nav i {
           display: none;
@@ -890,11 +893,10 @@
           TYPE_B = (cs.getPropertyValue("--field-end") || TYPE_A).trim();
         }
 
-        /* THE FIELD, RUN BACKWARDS AND THEN FORWARDS AGAIN.
-     `typeof`, not truthiness: on a failed script load PTLField is an
-     undeclared name, and `PTLField && …` throws a ReferenceError rather than
+        /* `typeof`, not truthiness: on a failed load PTLField is an undeclared
+     name, so `PTLField && …` throws a ReferenceError rather than
      short-circuiting. A null field is not a failure worth reacting to — the
-     page is a complete, readable document without it. */
+     page is a complete document without it. */
         const field =
           typeof PTLField !== "undefined"
             ? PTLField.mount(document.getElementById("c"), { mode: "form" })
@@ -934,27 +936,14 @@
             0.35 * smooth(p / OPENS_BY) + 0.65 * clamp(p / OPENS_BY),
           );
 
-        /* THIS PAGE KEEPS ITS OWN RESOLVE WINDOW, and has to.
-     ------------------------------------------------------------------------
-     gAt runs the film BACKWARDS — g falls from 0.94 to 0.30 as you scroll — so
-     the front page's window, whose whole point is to be welded to the six
-     beats of an argument this page does not have, lands here as "white and
-     unshadowed for the top fifth, warm only at the bottom". Measured: the
-     marks went from R-B +64.7 to -2.8 at a quarter of the way down.
-
-     There is no shared setting that is right for both, because the two pages
-     are not playing the same clock in the same direction. So this one keeps
-     the curve it was designed against: eased IN, over the stretch the field
-     actually occupies, which leaves the duotone intact down the page and lets
-     it resolve as the field recedes behind the document. */
-        /* NOT REVERTED HERE, unlike ptl-page.js. The front page's blue keeps its old
-     late window because that page has an ending to put the drain at. This one
-     runs the film backwards and has none: the same window leaves the whole
-     scroll unresolved, and the vertical wash — which the front page only gets
-     away with because the veil sits over the floor of the frame and takes the
-     saturation out of it — comes through raw as a cyan band across the bottom
-     of every screen. Its own window keeps the wash suppressed for most of the
-     page, which is what it was chosen for. */
+        /* THIS PAGE KEEPS ITS OWN RESOLVE WINDOW, and has to. gAt runs the film
+     BACKWARDS — g falls from 0.94 to 0.30 as you scroll — where ptl-page.js's
+     clock runs up, so its window (welded to six beats this page does not have)
+     lands here as white and unshadowed for the top fifth: measured, the marks
+     went from R-B +64.7 to -2.8 a quarter of the way down. There is no shared
+     setting right for both. Eased IN, over the stretch the field actually
+     occupies, which leaves the duotone intact and lets it resolve as the field
+     recedes behind the document. */
         const RES_A = 0.55,
           RES_B = 0.985;
         const resolveAt = (g) =>
@@ -1034,21 +1023,14 @@
           if (ticking) return;
           ticking = requestAnimationFrame(function step(ts) {
             ticking = 0;
-            /* The clamp exists for the one enormous delta a backgrounded tab
-     hands back on return. Applied to EVERY frame it dilated time on exactly
-     the devices already struggling — at 15fps the ambient clock ran at
-     0.75 s/s. Only a genuinely absurd gap is a returning tab; everything else
-     is a slow frame and should count for what it was. The same reading as
-     ptl-page.js, which found it first. */
+            /* Only a gap past 0.5s is a returning tab; everything else is a slow
+     frame and counts for what it was. Same clamp as ptl-page.js. */
             const raw = lastTs ? (ts - lastTs) / 1000 : 0.016;
             const dt = raw > 0.5 ? 0.016 : Math.min(raw, 0.25);
             lastTs = ts;
             if (!reduce) {
-              /* Per second, not per frame: AMB_DECAY is tuned at 60Hz, and
-     multiplied once a frame the scroll boost bled off twice as fast on a
-     120Hz screen as on a 60Hz one — the same gesture meaning different
-     things on different hardware, which is what rating the boost by
-     distance was supposed to stop. */
+              /* Per second, not per frame: AMB_DECAY is tuned at 60Hz, so once a
+     frame the boost bled off twice as fast at 120Hz. */
               vel *= Math.pow(AMB_DECAY, dt * 60);
               clock += dt * (AMB_IDLE + AMB_GAIN * Math.min(vel, 1.4));
             }

--- a/about.html
+++ b/about.html
@@ -70,8 +70,9 @@
       }
       /* .backers asks for Inter; without this its row of small caps fell out of
      the stack to system-ui, the only non-local face on the page. Not
-     preloaded — the reader arrives off `join us`, which is set in Inter and
-     already cached. */
+     preloaded — the reader arrives off the film's closing lockup, whose claim
+     line (.l3) is set in Inter, so the face is already cached. NOT off `join
+     us`: that is .cta, which index.html sets in Cormorant. */
       @font-face {
         font-family: Inter;
         src: url("/fonts/Inter.woff2") format("woff2");
@@ -810,10 +811,18 @@
           TYPE_B = "#ffffff";
         if (PF) {
           const cs = getComputedStyle(root);
-          INK = hex3(cs.getPropertyValue("--field"));
-          INK2 = hex3(cs.getPropertyValue("--field-end"));
-          TINT = hex3(cs.getPropertyValue("--tint"));
-          PAPER = hex3(cs.getPropertyValue("--paper"));
+          /* Fallbacks, and the same ones ptl-page.js uses: hex3 of an empty
+       string is [NaN, NaN, NaN], and NaN reaches gl.uniform3f without
+       complaint. Sharing the parser is only half of agreeing with the
+       other page — the defaults have to match too. */
+          INK = hex3(cs.getPropertyValue("--field") || "#ffffff");
+          INK2 = hex3(
+            cs.getPropertyValue("--field-end") ||
+              cs.getPropertyValue("--field") ||
+              "#ffffff",
+          );
+          TINT = hex3(cs.getPropertyValue("--tint") || "#000000");
+          PAPER = hex3(cs.getPropertyValue("--paper") || "#000000");
           /* From the ROOT rule, never the element we write --ink-live onto:
        reading our own output back would ratchet the type toward its target a
        frame at a time and never return. */
@@ -919,7 +928,14 @@
      that died with its context, this held the compositor open at 60fps to
      advance a number nobody reads. render() already returns immediately in
      both cases; this is the loop agreeing. */
-            if (field && !field.isDead() && !reduce && !document.hidden) tick();
+            if (
+              field &&
+              !field.isDead() &&
+              !field.isLost() &&
+              !reduce &&
+              !document.hidden
+            )
+              tick();
           });
         }
 
@@ -943,6 +959,21 @@
           if (field) field.idle();
           tick();
         });
+
+        /* A LOST CONTEXT STOPS THE LOOP, SO A RESTORED ONE HAS TO START IT.
+     The re-arm above now excludes isLost(), which is what keeps a loss from
+     re-arming at 60fps to draw nothing — but it also means nothing is asking
+     for frames once the context comes back. The field rebuilds itself on this
+     event; this is the page agreeing to start looking again. */
+        {
+          const cv = document.getElementById("c");
+          if (field && cv)
+            cv.addEventListener("webglcontextrestored", () => {
+              if (field.idle) field.idle();
+              render();
+              tick();
+            });
+        }
 
         /* ARRIVAL. Added by script only, so a reader with JS off gets the whole
      page at full opacity rather than an empty one. IntersectionObserver

--- a/about.html
+++ b/about.html
@@ -15,13 +15,6 @@
     <link rel="canonical" href="https://ptl.inc/about.html" />
     <meta name="theme-color" content="#000000" />
     <meta name="color-scheme" content="dark" />
-    <script>
-      {
-        const v = new URLSearchParams(location.search).get("v");
-        if (v === "2" || v === "3" || v === "4")
-          document.documentElement.dataset.v = v;
-      }
-    </script>
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <meta property="og:type" content="website" />
@@ -101,43 +94,6 @@
         --rule: #353535;
         --wash: rgba(0, 0, 0, 0.62);
         --tint: #c64a16;
-      }
-      /* Variation 4 — the control: one bit, nothing added. See index.html. */
-      :root[data-v="4"] {
-        --paper: #000000;
-        --ink: #ffffff;
-        --field: #ffffff;
-        --field-end: #ffffff;
-        --dim: #7c7c7c;
-        --mid: #8a8a8a;
-        --soft: #9e9e9e;
-        --rule: #333333;
-        --wash: rgba(0, 0, 0, 0.62);
-        --tint: #000000;
-      }
-      :root[data-v="2"] {
-        --paper: #d6d3d1;
-        --ink: #0c0a09;
-        --field: #0c0a09;
-        --field-end: #0c0a09;
-        --dim: #57534e;
-        --mid: #44403c;
-        --soft: #3b3735;
-        --rule: #9c9691;
-        --wash: rgba(214, 211, 209, 0.7);
-        --tint: #3e301e;
-      }
-      :root[data-v="3"] {
-        --paper: #dad2cf;
-        --ink: #0c0a09;
-        --field: #0000e0;
-        --field-end: #0c0a09;
-        --dim: #5b514e;
-        --mid: #473f3c;
-        --soft: #3d3634;
-        --rule: #a09490;
-        --wash: rgba(218, 210, 207, 0.72);
-        /* No --tint: this variation runs strictly one bit — see index.html. */
       }
 
       * {
@@ -725,7 +681,7 @@
 
     <div class="page">
       <header class="chrome">
-        <a class="wm" id="home" href="/">PREDICTIVE <br />TEXT LABS</a>
+        <a class="wm" href="/">PREDICTIVE <br />TEXT LABS</a>
         <nav class="nav"><i></i><span class="here">ABOUT</span></nav>
       </header>
 
@@ -906,8 +862,9 @@
         const reduceMQ = matchMedia("(prefers-reduced-motion: reduce)");
         let reduce = reduceMQ.matches;
 
-        /* The browser chrome is derived from the resolved paper rather than
-     restated, and the way back carries the variation with it. */
+        /* The renderer's palette, read out of the stylesheet rather than
+     restated here: index.html's :root is the source, this page mirrors it, and
+     the film is handed whatever the browser resolved. */
         const hex3 = (h) => {
           const n = (h || "").trim().replace("#", "");
           return [0, 2, 4].map((i) => parseInt(n.slice(i, i + 2), 16) / 255);
@@ -916,41 +873,21 @@
           INK2 = [1, 1, 1],
           PAPER = [0, 0, 0],
           TINT = [0, 0, 0];
-        /* Paper or a room — see uPrint in the renderer, and ptl-page.js for why it
-     is read off the ground rather than off the variant name. */
-        let PRINT = 0;
         /* Declared here, not beside resolveAt below: palette() runs before that
      block is reached, and a `let` read from above its own line throws. */
         let TYPE_A = "#ffffff",
           TYPE_B = "#ffffff";
-        /* The drop shadow is the indigo variant's alone — see uShadow in the
-     renderer. Read once: the variant cannot change without a reload. */
-        const SHADOW = root.dataset.v ? 0 : 1;
-        /* Variation 4 loses the ramp as well as the shadow — see index.html. */
-        const TONE = /^[34]$/.test(root.dataset.v || "") ? 0 : 1;
         {
           const cs = getComputedStyle(root);
-          const paper = cs.getPropertyValue("--paper").trim();
           INK = hex3(cs.getPropertyValue("--field"));
           INK2 = hex3(cs.getPropertyValue("--field-end"));
-          TINT = hex3(
-            cs.getPropertyValue("--tint") || cs.getPropertyValue("--paper"),
-          );
-          PAPER = hex3(paper);
-          const pl = 0.2126 * PAPER[0] + 0.7152 * PAPER[1] + 0.0722 * PAPER[2];
-          const pk = pl < 0.25 ? 0 : pl > 0.55 ? 1 : (pl - 0.25) / 0.3;
-          PRINT = pk * pk * (3 - 2 * pk);
+          TINT = hex3(cs.getPropertyValue("--tint"));
+          PAPER = hex3(cs.getPropertyValue("--paper"));
           /* Read from the ROOT rule, never from the element we write --ink-live
        onto — reading back our own output would ratchet the type toward its
        target a frame at a time and never return. */
           TYPE_A = (cs.getPropertyValue("--ink") || "#ffffff").trim();
           TYPE_B = (cs.getPropertyValue("--field-end") || TYPE_A).trim();
-          const [r, g, b] = PAPER;
-          document.querySelector("meta[name=theme-color]").content = paper;
-          document.querySelector("meta[name=color-scheme]").content =
-            0.2126 * r + 0.7152 * g + 0.0722 * b > 0.5 ? "light" : "dark";
-          const v = root.dataset.v;
-          if (v) document.getElementById("home").href = "/?v=" + v;
         }
 
         /* THE FIELD, RUN BACKWARDS AND THEN FORWARDS AGAIN.
@@ -1082,9 +1019,6 @@
             gap: 0.12,
             gain: gainAt(p),
             fov: 0.7,
-            shadow: SHADOW,
-            tone: TONE,
-            print: PRINT,
             mouse: [0, 0],
             act: 0,
             ink: INK,

--- a/about.html
+++ b/about.html
@@ -786,12 +786,21 @@
         const reduceMQ = matchMedia("(prefers-reduced-motion: reduce)");
         let reduce = reduceMQ.matches;
 
+        /* The field's own vocabulary, taken from the field. This page had its
+     own copies of all five helpers and they had already drifted apart from
+     ptl-page.js's — hex3 most dangerously, which expanded three-digit hex
+     there and guarded a missing token here, so `--paper: #000` would have
+     rendered on the front page and handed the shader NaN on this one.
+
+     No fallback bodies, because nothing that uses them runs without the field:
+     render() returns on a null field, and the arrival animation at the foot of
+     this file — the only part that stands on its own — uses none of them. */
+        const PF = typeof PTLField !== "undefined" ? PTLField : null;
+        const { hex3, clamp, lerp, smooth, mixHex } = PF || {};
+        const CLOSE = PF ? PF.CLOSE : { TO: 0.965 };
+
         /* The renderer's palette, read out of the stylesheet rather than
      restated here: index.html's :root is the source and this page mirrors it. */
-        const hex3 = (h) => {
-          const n = (h || "").trim().replace("#", "");
-          return [0, 2, 4].map((i) => parseInt(n.slice(i, i + 2), 16) / 255);
-        };
         let INK = [1, 1, 1],
           INK2 = [1, 1, 1],
           PAPER = [0, 0, 0],
@@ -799,7 +808,7 @@
         /* Outside the block below, which only assigns them. */
         let TYPE_A = "#ffffff",
           TYPE_B = "#ffffff";
-        {
+        if (PF) {
           const cs = getComputedStyle(root);
           INK = hex3(cs.getPropertyValue("--field"));
           INK2 = hex3(cs.getPropertyValue("--field-end"));
@@ -815,26 +824,24 @@
         /* `typeof`, not truthiness: on a failed load PTLField is an undeclared
      name, so `PTLField && …` throws rather than short-circuiting. A null field
      is not a failure — the page is a complete document without it. */
-        const field =
-          typeof PTLField !== "undefined"
-            ? PTLField.mount(document.getElementById("c"))
-            : null;
+        const field = PF ? PF.mount(document.getElementById("c")) : null;
 
-        /* OPEN is where the mark sits when the reader lands: exactly where the
-     front page left it, closed. Scrolling opens it out to WIDE and it STAYS
-     there. It used to close again at the bottom, mirroring the film — but a
-     closing mark is a small dense object in the middle of the frame, which is
-     where the team grid's second column lives, and it parked itself on a name.
-     Wide, the arch is a ground and overlaps nothing but texture. */
-        const OPEN = 0.94,
+        /* OPEN is where the mark sits when the reader lands: just short of where
+     the front page left it. Scrolling opens it out to WIDE and it STAYS there.
+     It used to close again at the bottom, mirroring the film — but a closing
+     mark is a small dense object in the middle of the frame, which is where the
+     team grid's second column lives, and it parked itself on a name. Wide, the
+     arch is a ground and overlaps nothing but texture.
+
+     DERIVED, NOT RESTATED. This was the literal 0.94 under a comment claiming it
+     was exactly the front page's last frame. It was not: that frame is CLOSE.TO,
+     and the two have been free to drift apart ever since — the hazard CLOSE's
+     own note in ptl-field.js describes. The 0.025 is the gap, and it is a real
+     decision: at CLOSE.TO the mark is a full stop, and this page opens with one
+     that is still legibly a mark. Move the gap, not the anchor. */
+        const OPEN = CLOSE.TO - 0.025,
           WIDE = 0.3,
           OPENS_BY = 1.0;
-        const clamp = (x) => (x < 0 ? 0 : x > 1 ? 1 : x);
-        const smooth = (x) => {
-          const t = clamp(x);
-          return t * t * (3 - 2 * t);
-        };
-        const lerp = (a, b, t) => a + (b - a) * t;
 
         /* Mostly linear, with only a soft start. A pure smoothstep flattens at
      BOTH ends, so the last fifth of the page read as frozen — 0.20 mean pixel
@@ -844,7 +851,7 @@
           lerp(
             OPEN,
             WIDE,
-            0.35 * smooth(p / OPENS_BY) + 0.65 * clamp(p / OPENS_BY),
+            0.35 * smooth(0, 1, p / OPENS_BY) + 0.65 * clamp(p / OPENS_BY),
           );
 
         /* THIS PAGE KEEPS ITS OWN RESOLVE WINDOW, and has to. gAt runs the film
@@ -857,12 +864,6 @@
           RES_B = 0.985;
         const resolveAt = (g) =>
           Math.pow(clamp((g - RES_A) / (RES_B - RES_A)), 2);
-        const mixHex = (a, b, t) => {
-          const A = hex3(a),
-            B = hex3(b);
-          const c = (i) => Math.round((A[i] + (B[i] - A[i]) * t) * 255);
-          return "rgb(" + c(0) + "," + c(1) + "," + c(2) + ")";
-        };
 
         /* And it RECEDES as the page stops being a film and becomes a document.
      The principles are a full-width table; there is no right half to give the

--- a/index.html
+++ b/index.html
@@ -53,11 +53,8 @@
     />
     <meta name="twitter:image" content="https://ptl.inc/og.png" />
 
-    <!-- Only the two faces on the FIRST FRAME are preloaded — the roman and the
-     mono. font-display:block means an unloaded face renders nothing at all,
-     so anything the opening frame sets has to be here; the comment below is
-     why the other two are deliberately not. Four faces ship, 147KB, all
-     local; these two are 64KB of it. -->
+    <!-- Only the faces the FIRST FRAME sets: font-display:block renders an
+     unloaded face as nothing at all. -->
     <link
       rel="preload"
       href="/fonts/Cormorant.woff2"
@@ -72,13 +69,11 @@
       type="font/woff2"
       crossorigin
     />
-    <!-- Cormorant-Italic and Inter are NOT preloaded. They are used only by the
-     closing lockup, eleven viewport-heights down, and at top priority they
-     contended with the roman that gates the LCP: measured on Slow 4G, the
-     roman finished 86ms AFTER an italic nothing could see yet. Dropping the
-     two preloads took LCP from 1640ms to 1260ms — 23% — with FCP unchanged at
-     156ms. The @font-face rules still fetch them, at normal priority, when
-     the finale first needs them. -->
+    <!-- Cormorant-Italic and Inter are NOT preloaded. Used only by the closing
+     lockup eleven viewport-heights down, at top priority they contended with
+     the roman that gates the LCP: dropping them took LCP 1640ms -> 1260ms on
+     Slow 4G with FCP unchanged. @font-face still fetches them, at normal
+     priority, when the finale needs them. -->
 
     <script type="application/ld+json">
       {
@@ -110,11 +105,9 @@
         font-weight: 100 900;
         font-display: block;
       }
-      /* The third face, and the only one not in the original kit. The closing claim
-     is a neo-grotesque, which neither Cormorant nor a monospace can stand in
-     for: it is uniform-stroke uppercase, and a mono at display size shows its
-     fixed advances badly (the I in MACHINES sits in a hole). Inter, variable,
-     latin subset, 48KB, local — no third-party request on this page. */
+      /* A uniform-stroke neo-grotesque for the closing claim, which neither
+     Cormorant nor a mono can stand in for — a mono at display size holes out
+     the I in MACHINES. Local, latin subset, 48KB: no third-party request. */
       @font-face {
         font-family: Inter;
         src: url("/fonts/Inter.woff2") format("woff2");
@@ -122,24 +115,14 @@
         font-display: block;
       }
 
-      /* THE PALETTE — one colourway, and this is it.
-     Every colour, including the two the shader resolves its 1-bit output to,
-     comes from here: the renderer is handed --field and --paper at draw time,
-     so the film and the type cannot disagree about the ground they are on.
-     --field is a separate token from --ink because the film's colour and the
-     writing's are allowed to differ — the field is an event in the picture,
-     not a change of voice in the copy. --tint is the mark at its DIMMEST, the
-     dim end of the black-body ramp the shader walks up to --field.
-
-     The ground is PITCH BLACK — the fact ptl-field.js points back here for. It
-     was indigo for a long time; the greys were re-matched to black by
-     LUMINANCE rather than by eye, so the type sits exactly where it sat:
-     5.77:1 for the chrome's --dim, 7.10:1 for the body's --mid, both clear AA.
-
-     --wash is the defocus dome: a translucent SHEET of the paper colour over a
-     plain blur, not a brightness() term. Brightening only works when the paper
-     is at one end of the range; on a mid-tone ground it paints a visible bright
-     dome over the page instead of lowering the contrast behind the copy. */
+      /* THE PALETTE. Every colour comes from here, including the two the shader
+     resolves its 1-bit output to: the renderer is handed --field and --paper at
+     draw time, so film and type cannot disagree about their ground. --field is
+     separate from --ink because the film's colour and the writing's are allowed
+     to differ; --tint is the mark at its DIMMEST, the low end of the shader's
+     black-body ramp. The greys are matched to the black ground by LUMINANCE,
+     not by eye: --dim 5.77:1, --mid 7.10:1, both clear AA. --wash is the
+     defocus dome — a translucent SHEET of the paper colour, not brightness(). */
       :root {
         --paper: #000000;
         --ink: #f4eada;
@@ -159,9 +142,9 @@
         padding: 0;
         box-sizing: border-box;
       }
-      /* --ink-live is --ink travelling to --field-end on the resolve clock, set
-     from JS each frame. The fallback is the whole no-JS story: without script
-     the type is simply --ink and nothing is lost. */
+      /* --ink-live is --ink travelling to --field-end on the resolve clock,
+     written from JS each frame. The fallback is the whole no-JS story: without
+     script the type is simply --ink. */
       html,
       body {
         background: var(--paper);
@@ -172,14 +155,11 @@
         overflow-x: hidden;
       }
 
-      /* The argument, in the markup. -----------------------------------------
-     Every visible word on this page is drawn by script into containers that
-     are choreographed against scroll, which would leave a crawler, a link
-     preview and a screen reader with a page containing no words at all. So
-     the copy lives HERE, as ordinary semantic HTML, and the script reads it
-     out of the DOM rather than carrying its own copy of it. One source of
-     truth; the rendered version is marked aria-hidden so it is not announced
-     twice. */
+      /* THE ARGUMENT, IN THE MARKUP. Every visible word is drawn by script into
+     scroll-choreographed containers, which would leave a crawler, a link
+     preview and a screen reader with no words at all. The copy lives here
+     instead, as ordinary semantic HTML, and the script reads it out of the DOM;
+     the rendered version is aria-hidden so it is not announced twice. */
       .story {
         position: absolute;
         width: 1px;
@@ -205,11 +185,9 @@
         height: 100%;
         display: block;
       }
-      /* The type is NOT inside .stage. .stage has to clip — it holds the canvas —
-     and with the copy inside it, raising the browser's base font size grew the
-     bottom-anchored block up past the top edge and the overflow rule deleted
-     it. Content that is merely too big must still be readable; content that is
-     clipped away is gone. Same fixed frame, no clip. */
+      /* The type is NOT inside .stage: .stage has to clip, and with the copy
+     inside it a raised base font size grew the bottom-anchored block past the
+     top edge and overflow deleted it. Too big is readable; clipped is gone. */
       .type {
         position: fixed;
         inset: 0;
@@ -219,21 +197,15 @@
       .type a {
         pointer-events: auto;
       }
-      /* The LAYER is transparent to the pointer; the WORDS are not. Without this
-     the copy is text you cannot put a cursor in — no I-beam, no selection, no
-     copying a line out of it — because the whole layer above the canvas was
-     waved through. Only the text boxes take the pointer back: the empty frame
-     around them stays transparent, so nothing intercepts a scroll and the
-     mark keeps reading the pointer (which it does from window, so events
-     landing on the copy still reach it by bubbling). The finale's lines are
-     handled in fadeLine, which knows when a line has faded out from under
-     itself and should stop hit-testing an empty band. */
+      /* The LAYER is transparent to the pointer; the WORDS are not — otherwise
+     the copy cannot be selected or copied. Only the text boxes take the pointer
+     back, so nothing intercepts a scroll and the mark keeps reading the pointer
+     from window. fadeLine stops hit-testing a band once its line has faded. */
       .blk h1,
       .blk p {
         pointer-events: auto;
       }
-      /* And selection is drawn, not left to the UA's blue — one more inversion,
-     which is the whole vocabulary of the page. */
+      /* Selection is drawn, not left to the UA's blue: one more inversion. */
       ::selection {
         background: var(--ink);
         color: var(--paper);
@@ -264,8 +236,7 @@
         letter-spacing: 0.24em;
       }
       /* --dim, not --ink. White-on-the-field measured 1.00:1 for 15% of the
-     scroll on a foldable's unfolded panel, where this element is visible;
-     the weight carries the emphasis instead. */
+     scroll on a foldable's unfolded panel; the weight carries the emphasis. */
       .nav b {
         color: var(--dim);
         font-weight: 500;
@@ -276,10 +247,10 @@
         background: var(--rule);
         font-style: normal;
       }
-      /* The only interactive element on the page, so it has to announce itself as
-     one on hover and on keyboard focus alike. The underline is offset clear of
-     the caps rather than crowding them, and the trailing letter-space is pulled
-     back so the rule stops with the last letter instead of running past it. */
+      /* The page's only interactive element, so it has to announce itself on
+     hover and on keyboard focus alike. The underline sits clear of the caps and
+     the trailing letter-space is pulled back so the rule stops with the last
+     letter. */
       .nav a {
         position: relative;
         color: var(--dim);
@@ -289,9 +260,9 @@
         -webkit-tap-highlight-color: transparent;
       }
       /* The drawn box is 45.7 x 10.9. A pseudo-element rather than padding,
-     because .chrome is an align-items:center flex row and the underline's
-     offset is calibrated — this changes the hit rectangle and moves nothing.
-     ~58 x 44, which is the platform minimum with no layout consequence. */
+     because .chrome is a centred flex row and the underline's offset is
+     calibrated: this grows the hit target to ~58 x 44, the platform minimum,
+     and moves nothing. */
       .nav a::after {
         content: "";
         position: absolute;
@@ -301,9 +272,9 @@
         height: 44px;
         transform: translateY(-50%);
       }
-      /* On a phone there is no hover, so the page's only control was pixel-
-     identical to the inert wordmark beside it — same colour, size, family and
-     weight, no underline. The affordance has to exist without a cursor. */
+      /* No hover on a phone, where the page's only control was pixel-identical
+     to the inert wordmark beside it. The affordance has to exist without a
+     cursor. */
       @media (hover: none) {
         .nav a {
           color: var(--ink);
@@ -321,8 +292,7 @@
       }
       /* A real ring, not a 1px underline sitting on the film: the substituted
      underline measured 82.8% of its ink below 3:1 at the worst beat. The
-     paper-coloured spread is what makes the ring legible over the halftone
-     rather than over whatever happens to be behind it. */
+     paper-coloured spread is what makes the ring legible over the halftone. */
       .nav a:focus-visible {
         outline: 2px solid var(--ink);
         outline-offset: 0.35em;
@@ -330,19 +300,12 @@
         text-decoration: none;
       }
 
-      /* NARROW SCREENS — the counter goes.
-     ------------------------------------------------------------------------
-     The wordmark needs ~205px at this tracking and the right-hand group ~140px
-     with the counter in it; a 390px phone has 313px after padding, so the bar
-     wrapped and interleaved the company name with the section number. Shrinking
-     the type would have saved all three elements by making all three worse, and
-     the tracking is most of what makes this bar read as a mark rather than a
-     nav. So the counter — the only one of the three that is decoration rather
-     than a job — is dropped instead, along with its rule, and the wordmark and
-     the link keep their size and their letterspacing.
-
-     nowrap on both is the belt: if a future string does overflow, it overflows
-     visibly instead of silently folding in half. */
+      /* NARROW SCREENS — the counter goes. The wordmark needs ~205px at this
+     tracking and the right-hand group ~140px with the counter; a 390px phone
+     has 313px after padding, so the bar wrapped. Shrinking the type would save
+     all three by making all three worse, and the tracking is most of what makes
+     this bar read as a mark rather than a nav. nowrap is the belt: an overflow
+     overflows visibly. */
       .chrome .wm,
       .nav {
         white-space: nowrap;
@@ -350,20 +313,15 @@
       .wm br {
         display: none;
       }
-      /* On a desktop the form never reaches the header. On a phone — and on any
-     short viewport — it does, and the bar ends up set over pure white cells.
-     A scrim of the page's own ground, only there. */
-      /* .82 was the one value that destroyed the thing it was protecting. The
-     chrome's ink is --dim, mid-grey: it reads 5.03:1 on black AND 4.17:1 on
-     white, so it survives both extremes — and dies only on the MID-TONES an
-     82% scrim manufactures. Measured, 96.7% of ABOUT's core pixels fell below
-     3:1 at the worst beat, median 1.41:1; with the scrim removed entirely,
-     6.1%. It was the cause, not the cure, for ~2 viewport-heights of scroll on
-     every phone.
+      /* On a phone, and on any short viewport, the form reaches the header and
+     the bar is set over pure white cells. A scrim of the page's own ground,
+     only there.
 
-     Full paper to 72% instead. The type sits 29-60% down an 83px bar, so this
-     covers both wordmark lines and the link and still fades out at the bar's
-     bottom edge. Built from --paper, so it is the page's own ground. */
+     FULL paper to 72%, not a partial scrim: --dim reads 5.03:1 on black and
+     4.17:1 on white, so it survives both extremes and dies only on the
+     MID-TONES a partial scrim manufactures — measured, 96.7% of ABOUT's core
+     pixels below 3:1 at the worst beat against 6.1% with none at all. The type
+     sits 29-60% down an 83px bar. */
       @media (max-width: 560px), (max-height: 560px) {
         .chrome::before {
           content: "";
@@ -378,9 +336,8 @@
           );
         }
       }
-      /* max-height too: a landscape phone is 844 wide and never matched, so it
-     got the desktop bar — 87.7px, 22% of a 390-tall frame, and section 03's
-     headline cleared it by 10px. */
+      /* max-height too: a landscape phone is 844 wide, never matched, and got
+     the desktop bar — 87.7px, 22% of a 390-tall frame. */
       @media (max-width: 560px), (max-height: 560px) {
         .chrome {
           padding: 1.5rem 1.2rem;
@@ -393,10 +350,8 @@
         .nav {
           gap: 0;
         }
-        /* Stacked, and broken where the name breaks — PREDICTIVE / TEXT LABS,
-       not wherever the measure happened to run out. Leading has to open up
-       too: the bar is set at line-height 1, which is right for one line and
-       far too tight for two. */
+        /* Broken where the NAME breaks, not where the measure ran out; and the
+       leading has to open with it, the bar being set at line-height 1. */
         .wm br {
           display: inline;
         }
@@ -404,13 +359,11 @@
           line-height: 1.62;
         }
       }
-      /* The page declares viewport-fit=cover, so on a notched phone the bar
-     would otherwise lay itself into the cutout it opted into.
-     AFTER the 560px block on purpose, and unconditional: on a landscape phone
-     (max-height matches, max-width does not) it beats that block on all three
-     sides — 2.4rem, not 1.2/1.5 — which is the frame the bar was retuned on.
-     Do NOT fold it into the base rule above; about.html's is folded and that
-     is not the same rule. */
+      /* viewport-fit=cover, so the bar would otherwise lay itself into the
+     cutout. AFTER the 560px block on purpose and unconditional: on a landscape
+     phone (max-height matches, max-width does not) it beats that block on all
+     three sides, at the 2.4rem the bar was retuned on. Do NOT fold it into the
+     base rule; about.html's is folded and is not this rule. */
       .chrome {
         padding-left: max(2.4rem, env(safe-area-inset-left));
         padding-right: max(2.4rem, env(safe-area-inset-right));
@@ -424,33 +377,22 @@
         }
       }
 
-      /* DEPTH OF FIELD, DOWNWARD.
-     ------------------------------------------------------------------------
-     The picture is lit from above, and the floor of the frame is that light
-     on water: what separates a reflection from the thing reflected is focus.
-     So the frame holds its edge at the top and loses it toward the bottom,
-     over a ramp that also deepens the ground — blur alone reads as fog, and
-     the darkening is what makes it read as depth.
+      /* DEPTH OF FIELD, DOWNWARD. The floor of the frame is light on water, and
+     what separates a reflection from the thing reflected is focus — so the
+     frame loses its edge toward the bottom, over a ramp that also deepens the
+     ground: blur alone reads as fog, the darkening is what reads as depth.
 
-     A backdrop-filter with a MASK, which is what makes it progressive: the
-     radius is constant and the mask decides how much of the blurred backdrop
-     is allowed through, so the picture crosses from sharp to soft over a
-     distance instead of at an edge. Same mechanism as .veil below, which is
-     why there is no new machinery here. 0 to 28px over the bottom half of the
-     frame, starting at the mark's own centre.
+     The MASK is what makes it progressive — constant radius, the mask deciding
+     how much blurred backdrop comes through — so it crosses from sharp to soft
+     over a distance rather than at an edge. Same mechanism as .veil below.
 
-     Not in the shader, though it was built there first — as a depth term
-     inside the mark's own feather. It is here instead because softening the
-     MARK is the trade this page refuses everywhere else, while softening the
-     FRAME leaves every mark the shape it was drawn.
+     Not in the shader, where it was first a depth term inside the mark's own
+     feather: softening the FRAME leaves every mark the shape it was drawn, and
+     softening the MARK is the trade this page refuses.
 
-     ON THE FILM'S OWN CLOCK. --resolved is the number the type resolves on,
-     published by ptl-page.js; at the close it is 1 and this is gone. The last
-     frame is sharp to the floor, which is the point of the last frame. */
-      /* PHONE ONLY. On a wide frame the mark keeps the upper two thirds and the
-     copy has the floor, so there is no depth to describe down there — the
-     bottom of the frame is where the argument is written, and blurring it
-     would be blurring the ground the words stand on. */
+     --resolved is the film's own clock, published by ptl-page.js: at the close
+     it is 1 and this is gone. PHONE ONLY — on a wide frame the copy has the
+     floor, and blurring it would blur the ground the words stand on. */
       @media (max-width: 560px) {
         .deep {
           position: absolute;
@@ -474,28 +416,18 @@
         }
       }
 
-      /* A dome of defocus rising off the bottom edge.
-     ------------------------------------------------------------------------
-     The ellipse is centred at 50% 100% — the very bottom of the viewport — so
-     only its top half is ever on screen and the rest of the circle is cut off
-     below the fold. That gives a semicircular ground for the copy that has no
-     visible shape of its own: no top edge to read as a card, no left or right
-     edge at all, just density falling away as you move up and out.
+      /* A dome of defocus rising off the bottom edge. Centred at 50% 100%, so
+     only its top half is ever on screen: a ground for the copy with no shape of
+     its own — no top edge to read as a card, no side edges, just density
+     falling away.
 
-     It works WITH the shader's keep-out rather than replacing it, which is why
-     both are here. The keep-out handles the centre column, where the copy
-     actually sits and where a hard mark would be unreadable. This handles
-     everything that merely drifts NEAR the copy — the arch's legs, the outer
-     ring of the lattice — which the keep-out deliberately leaves sharp. */
-      /* saturate(0) so the defocus carries VALUE and not HUE. The wash is already
-     the paper colour, but it is translucent on purpose — a defocus, not an
-     eraser — and the ~28% of the field still showing through arrives with its
-     own colour. That colour is warm — --field is a cream and --tint an orange
-     — so without this the dome behind the copy comes out tinted: a third
-     colour, on a page that has two. Desaturating the backdrop first means what
-     bleeds through is only light and dark, and the dome reads as the paper
-     defocused. NOT a no-op, and not removable: it changes what is drawn on
-     every frame the dome is over the field. */
+     It works WITH the shader's keep-out, which handles the centre column where
+     the copy sits; this handles what merely drifts NEAR it — the arch's legs,
+     the lattice's outer ring — which the keep-out leaves sharp.
+
+     saturate(0) so the defocus carries VALUE and not HUE: the ~28% of the field
+     showing through the wash is warm, and would otherwise tint the dome a third
+     colour on a two-colour page. Not a no-op. */
       .veil {
         position: absolute;
         inset: 0;
@@ -518,13 +450,11 @@
         );
       }
 
-      /* Short viewports need a far bigger dome — the copy occupies most of a
-     landscape phone, and 68% of 390px puts the mask's opaque core below where
-     the words start. This is a media query and NOT max(68%,26rem) inside the
-     gradient: Chromium does not parse a CSS math function in a gradient size,
-     drops the whole mask-image as invalid, and then backdrop-filter blurs the
-     entire page with nothing masking it. WebKit accepts it, which is exactly
-     how it shipped. */
+      /* Short viewports need a far bigger dome: 68% of a 390px frame puts the
+     mask's opaque core below where the words start. A media query and NOT
+     max(68%,26rem) inside the gradient — Chromium drops a math function there
+     as invalid, taking the whole mask with it, and backdrop-filter then blurs
+     the page unmasked. WebKit accepts it, which is how it shipped. */
       @media (max-height: 620px) {
         .veil {
           -webkit-mask-image: radial-gradient(
@@ -542,39 +472,27 @@
         }
       }
 
-      /* ON A PHONE THE DOME IS ONLY FOR THE ENDING.
-     The defocus exists to give bottom-anchored copy a ground. On a phone the
-     copy is no longer bottom-anchored — it sits in the disc — so through the
-     whole argument the dome has nothing under it to serve, and what it does
-     instead is smother the bottom of the form: the ring's lower arc lands in
-     the middle of the mask's opaque core and comes back as a smudge, which is
-     why the frame read as an arch floating over an empty band rather than as
-     a circle.
-
-     The ending is the exception, and it is the whole reason this fades rather
-     than being deleted. The finale IS on the floor — .fin-a/b/c are positioned
-     by finale() against the bottom of the frame — so it needs exactly the
-     ground the beats do not.
-
-     --ending is published by ptl-page.js as a plain number, 0 through the
-     film and 1 across the finale's entrance. The page states how far into the
-     ending it is; this rule decides what that is worth on a phone. On a wide
-     frame nothing reads the property and the dome is unconditional, as
-     before. */
+      /* ON A PHONE THE DOME IS ONLY FOR THE ENDING. The defocus exists to give
+     bottom-anchored copy a ground; on a phone the copy sits in the disc
+     instead, so the dome smothers the ring's lower arc into a smudge — which is
+     why the frame read as an arch over an empty band rather than a circle. The
+     finale IS on the floor (.fin-a/b/c are placed by finale() against the
+     bottom of the frame) and does need that ground, hence a fade rather than a
+     deletion. --ending is published by ptl-page.js; on a wide frame nothing
+     reads it and the dome is unconditional. */
       @media (max-width: 560px) {
         .veil {
           opacity: var(--ending, 0);
         }
       }
 
-      /* The top bound is what keeps a grown block off the chrome, and it has to
-     be written against the chrome's RENDERED height — which doubles with the
-     root font too, so a plain rem bound would not clear a two-line wordmark.
-     max(…, env()) tracks it because the chrome's own padding is written the
-     same way. */
+      /* The top bound keeps a grown block off the chrome, and has to be written
+     against the chrome's RENDERED height — which doubles with the root font, so
+     a plain rem bound would not clear a two-line wordmark. max(…, env()) tracks
+     it because the chrome's own padding is written the same way. */
       .copy {
-        /* Named once, because the mobile rule below has to subtract exactly
-       this to get back to viewport coordinates. */
+        /* Named once: the mobile rule below subtracts exactly this to get back
+       to viewport coordinates. */
         --copy-top: calc(max(1.5rem, env(safe-area-inset-top)) + 4.5rem);
         position: absolute;
         left: 50%;
@@ -585,16 +503,12 @@
         bottom: 4.2rem;
       }
       /* NO overflow-y:auto here, deliberately, and it was tried. The descender
-     fix below pads each line by .18em and pulls it back with a negative
-     margin — which nets to zero for LAYOUT but not for scrollHeight, so the
-     block measures 269 against a 266 client height at every size. With
-     `overflow-y:auto` that 3px makes it a live scroll container at DEFAULT
-     text size, and a wheel starting over the copy was swallowed by a
-     container with 3px to give: measured, scrollY 0 -> 0 where it should be
-     0 -> 900. overscroll-behavior:contain made it worse, not better.
-     The reachability of over-large text is carried instead by the viewport
-     cap on the type below and by .copy's top bound above, which together stop
-     the block outgrowing the frame in the first place. */
+     fix below nets to zero for LAYOUT but not for scrollHeight, so the block
+     measures 269 against a 266 client height — enough to make it a live scroll
+     container at DEFAULT text size, where a wheel starting over the copy was
+     swallowed by a container with 3px to give (scrollY 0 -> 0 where it should
+     be 0 -> 900). Over-large text is held instead by the viewport cap on the
+     type below and .copy's top bound above. */
       .blk {
         position: absolute;
         left: 50%;
@@ -606,13 +520,10 @@
       .blk.on {
         visibility: visible;
       }
-      /* WHERE THE COPY IS, AS A NUMBER THE SCRIPT CAN READ.
-     The shader clears a band at the bottom of the frame so the copy has
-     somewhere clean to sit — see uKeep in ptl-field.js. Which band that should
-     be is not the shader's business, it is this rule's: below, the copy stops
-     being on the floor. Rather than have the script carry its own copy of the
-     breakpoint and the two drift, the breakpoint stays here, once, and the
-     script reads the answer off the root. */
+      /* WHERE THE COPY IS, AS A NUMBER THE SCRIPT CAN READ. The shader clears a
+     band for the copy (uCopy in ptl-field.js); WHICH band is this rule's
+     business, since below, the copy stops being on the floor. The breakpoint
+     stays here once and the script reads the answer off the root. */
       :root {
         --phone: 0;
       }
@@ -622,44 +533,27 @@
         }
       }
 
-      /* ON A PHONE THE COPY SITS IN THE CIRCLE, NOT ON THE FLOOR.
-     Bottom-anchoring is right on a landscape frame: the mark fills the upper
-     half, the copy takes the lower, and the two are in balance. Portrait
-     inverts that. The mark becomes a band across the top with a deep dark
-     disc under it, the copy is pinned 4.2rem off the bottom edge, and the
-     middle of the frame — the part the form is actually drawing — is empty,
-     with the words crowded into the last fifth as if they had fallen there.
+      /* ON A PHONE THE COPY SITS IN THE CIRCLE, NOT ON THE FLOOR. Bottom-
+     anchoring balances a landscape frame; portrait inverts it, leaving the
+     middle of the frame — the part the form is actually drawing — empty, with
+     the words crowded into the last fifth.
 
-     48dvh IS THE CIRCLE'S CENTRE, not an eyeballed nudge. The form is a ring
-     of radius r about (0.5W, 0.5H - cy*base), and cy is
-     track(g, 0.00, 0.30, -0.80, 0.02) — it reaches 0.02 by the end of the
-     first beat and holds there for the rest of the film, so the centre is
-     fixed at 0.5H - 0.02*base. In portrait base is the height (the long side,
-     max(H, W/1.78)), which makes it 0.48H. Checked against the render at
-     three scroll positions: the predicted underside of the crown lands within
-     a few px of the measured one. The circle itself cannot be measured
-     directly here — at 390 wide its inner edge runs off both sides of the
-     frame, which is exactly why this is derived rather than eyeballed.
+     48dvh IS THE CIRCLE'S CENTRE, derived rather than eyeballed: the ring is
+     centred at 0.5H - cy*base, and cy = track(g, 0.00, 0.30, -0.80, 0.02)
+     reaches 0.02 by the end of the first beat and holds, so in portrait, where
+     base is the height, the centre is 0.48H. (It cannot be measured directly —
+     at 390 wide the ring's inner edge runs off both sides of the frame.)
 
-     dvh, not vh: the shader's base comes from the canvas's own height, which
-     follows the URL bar, and vh does not. (The warning against dvh in
-     ptl-page.js is about the DOCUMENT's height, where a bar that hides
-     mid-scroll would move the film under the reader. This is one offset in a
-     fixed layer that is meant to track the canvas.) --copy-top comes back off
-     because .blk is positioned inside .copy, not against the frame.
+     dvh, not vh: the shader's base is the canvas's own height, which follows
+     the URL bar. --copy-top comes back off because .blk sits inside .copy.
 
-     The finale keeps the floor and is untouched: it is .fin-a/b/c in a layer
-     of its own, positioned by finale() in JS, not a .blk. The closing lockup
-     is the one moment that IS bottom-weighted on purpose — the mark has
-     closed above it and the words land beneath.
+     Portrait only — a landscape phone is 390 tall with the arch across most of
+     it, and this would lay the copy onto the bright of the mark. The finale
+     keeps the floor: .fin-a/b/c are placed by finale(), not .blk.
 
-     Portrait only. A landscape phone is 390 tall with the arch across most of
-     it, and this would lay the copy straight onto the bright of the mark.
-
-     One side effect, stated: .blk h1's 0.32em of ascender padding used to
-     grow the box upward off a fixed bottom edge and move nothing. Off a
-     centre it moves the glyphs down by half of it, about 5px here. Constant
-     across every beat, so it reads as position rather than as drift. */
+     Side effect: .blk h1's 0.32em of ascender padding moved nothing off a fixed
+     bottom edge; off a centre it lowers the glyphs ~5px, constant across every
+     beat. */
       @media (max-width: 560px) {
         .blk {
           top: calc(50dvh - var(--copy-top));
@@ -667,32 +561,18 @@
           transform: translate(-50%, -50%);
         }
       }
-      /* THE BOX MUST CONTAIN THE INK.
-     ------------------------------------------------------------------------
-     A mask clips its element to `mask-clip`, which defaults to the border box,
-     and at this line-height Cormorant's descenders hang below the content box
-     — so the tail of every g and y was being sliced off flat. No mask-repeat
-     value rescues that: the clip happens before the layers are even consulted.
-     `mask-clip:no-clip` is the declaration that means what we want and it
-     parses in all three engines, but only Firefox actually honours it; on
-     Chromium and WebKit the element is still cropped to the border box.
+      /* THE BOX MUST CONTAIN THE INK. A mask clips to `mask-clip`, which
+     defaults to the border box, and at this line-height Cormorant's descenders
+     hang below the content box — so the tail of every g and y was sliced off
+     flat. `mask-clip:no-clip` parses in all three engines but is honoured only
+     by Firefox, so the box is grown to hold the overhang and pulled back by the
+     same amount: just a bigger box, and the margins net out under collapsing.
 
-     So the box is grown to hold the overhang instead, and pulled back by the
-     same amount so nothing moves. That works everywhere because it is not a
-     masking feature at all — it is just a bigger box. The margin nets out
-     under collapsing too (a negative and a positive collapse to their sum,
-     and the padding adds it straight back), so the measured gap down to the
-     body is exactly what it was.
-
-     The top needs it too, but only on the headline and only sometimes: at the
-     landscape-phone measure the Cormorant ascenders overflow upward and
-     Chromium was shaving 68 device px off them, where WebKit and Firefox laid
-     them out just inside. It gets padding with no compensating margin, because
-     .blk is anchored to its BOTTOM — the block simply grows upward and not one
-     glyph moves. That does shift the border-box origin the 12px lattice is
-     laid from, which re-phases the halftone by a fraction of a cell; the
-     lattice is a dissolve texture with no registration to anything, so that
-     costs nothing, and a cropped ascender is not nothing. */
+     The top needs it on the headline only, where Chromium shaved 68 device px
+     off the ascenders at the landscape-phone measure. No compensating margin,
+     because .blk is anchored to its BOTTOM and simply grows upward — which
+     re-phases the 12px lattice by a fraction of a cell. The lattice registers
+     to nothing, so that costs nothing; a cropped ascender is not nothing. */
       .blk h1,
       .blk p {
         padding-bottom: 0.18em;
@@ -701,44 +581,26 @@
       .blk h1 {
         padding-top: 0.32em;
       }
-      /* Two things at once.
-     The vw term needed 869px before it engaged, so the headline was a FIXED
-     30.4px at every width from 320 to 430 — at 320 that set as six lines of
-     15-19 characters. 7.1vw engages across the whole phone range: 22.7px at
-     320, 30.5px at 430, so the largest phone keeps today's size and the
-     smallest gets a real reduction.
-     And the min() OUTSIDE the clamp is what stops a raised text size deleting
-     the copy. .blk is bottom-anchored inside a position:fixed layer, so the
-     block grows UPWARD past y=0 where there is no scroll container and no
-     overflow — at 200% text size 76% of one headline was simply gone, with no
-     scroll position that could recover it. min() inside the clamp does not
-     work: the rem floor wins and nothing changes. */
-      /* AND A MEASURE OF ITS OWN, NARROWER THAN THE COLUMN.
-     At .copy's full 60rem the two long beats — COMMIT and PRICE — set as two
-     lines of nearly sixty characters, a paragraph measure on type this size,
-     while the opening beat beside them ran to three. Three lines each is the
-     shape the argument wants: one rhythm from beat to beat, and no line long
-     enough to need a return sweep.
+      /* Two things at once. The vw term needed 869px before it engaged, so the
+     headline was a FIXED 30.4px from 320 to 430 — six lines of 15-19 characters
+     at 320. 7.1vw engages across the phone range: 22.7px at 320, 30.5px at 430.
+     And the min() OUTSIDE the clamp stops a raised text size deleting the copy:
+     .blk is bottom-anchored in a fixed layer, so the block grows past y=0 where
+     there is no scroll container — at 200% text size 76% of one headline was
+     gone. Inside the clamp it does nothing; the rem floor wins. */
+      /* AND A MEASURE OF ITS OWN, NARROWER THAN THE COLUMN. At .copy's full
+     60rem the two long beats set as two lines of nearly sixty characters while
+     the opening beat ran to three; three lines each is the shape the argument
+     wants.
 
-     IN em, AND THAT IS THE WHOLE TRICK. The size above is capped by 5.6vh, so
-     the headline is 51px on a tall screen and 43px on a 768-high laptop — and
-     a measure in rem holds a fixed number of PIXELS while the type shrinks
-     underneath it, which is a different number of characters to the line. Set
-     in px it worked at 900 high and dropped PRICE back to two lines at 768.
-     em resolves against the element's own font-size, so the measure is a
-     character count and the line count stops depending on the window's
-     height. Measured at 900, 982, 1080 and 768 high: the window is 13.5em to
-     18em, the SAME window at every one of them.
-
-     16em, not an edge: below 13.5 the opening beat breaks to four, above 18
-     the two long ones fall back to two, and everything between renders
-     3/2/2/3/3 alike, because text-wrap:balance minimises the longest line
-     once the count is fixed. The middle is where an edit to the copy can move
-     without taking the composition with it.
-
-     It binds only while the column is wider than it — around 930px and up.
-     Below that 86vw is already narrower and the viewport sets the count, as
-     it did before. */
+     IN em, AND THAT IS THE WHOLE TRICK. The size above is capped by 5.6vh, so a
+     measure in rem holds a fixed number of PIXELS while the type shrinks under
+     it — in px it worked at 900 high and dropped PRICE to two lines at 768. em
+     makes the measure a character count, so the line count stops depending on
+     the window's height: 13.5em to 18em is the same window at 768, 900, 982 and
+     1080. 16em is the middle of that, not an edge — below 13.5 the opening beat
+     breaks to four, above 18 the long ones fall back to two. Binds only above
+     about 930px; below that 86vw is narrower and the viewport sets the count. */
       .blk h1 {
         font:
           300 min(clamp(1.55rem, 7.1vw, 3.2rem), 5.6vh)/1.14 Cormorant,
@@ -749,8 +611,8 @@
         margin-left: auto;
         margin-right: auto;
       }
-      /* `balance` sets the paragraph at the narrowest measure that still holds its
-     line count, so a two-line body is two EVEN lines rather than a long one
+      /* `balance` sets the paragraph at the narrowest measure that still holds
+     its line count, so a two-line body is two EVEN lines rather than a long one
      and a stub. max-width is the ceiling it balances within. */
       .blk p {
         margin-top: 1.9rem;
@@ -764,30 +626,22 @@
         margin-left: auto;
         margin-right: auto;
       }
-      /* And on a phone it sits closer to what it qualifies. 1.9rem is a wide
-     frame's gap, where the block has the whole floor to breathe on; inside a
-     centred block on a phone it reads as a break between two thoughts rather
-     than as one thought and its footnote. Written AFTER the rule it overrides
-     rather than up with the other phone rules: same specificity, so source
-     order is the whole argument. */
+      /* Closer to what it qualifies on a phone: 1.9rem is a wide frame's gap,
+     where the block has the whole floor to breathe on; inside a centred block
+     it reads as a break between two thoughts. Written AFTER the rule it
+     overrides — same specificity, so source order is the whole argument. */
       @media (max-width: 560px) {
         .blk p {
           margin-top: 0.95rem;
         }
       }
 
-      /* THE FINALE — one sentence, three registers, two destinations.
-     ------------------------------------------------------------------------
-     Everywhere else a section is a paragraph that resolves and disintegrates
-     in place. The last one is a lockup that MOVES: the name and the verb ride
-     up and out of frame, and the claim rises into a fixed spot beneath the
-     mark and stays there while the mark closes.
-
-     So it is built as two independently-positioned groups, not one block —
-     .fin-a (the name + the verb) and .fin-b (the claim). They travel together
-     while they are one lockup, then .fin-a is handed a second move and leaves.
-     Their spacing while joined is measured from the DOM, so the joined state
-     is exactly what normal flow would have produced. */
+      /* THE FINALE — one sentence, three registers, two destinations. Every
+     other section resolves and disintegrates in place; this one MOVES, the name
+     and the verb riding up and out of frame while the claim rises into a fixed
+     spot beneath the mark and stays. Hence two independently-positioned groups
+     rather than one block, with their joined spacing measured from the DOM so
+     it is exactly what normal flow would have given. */
       .finale {
         position: absolute;
         inset: 0;
@@ -808,43 +662,26 @@
         will-change: transform;
       }
 
-      /* THE ONE THING YOU CAN DO.
-     ------------------------------------------------------------------------
-     The page has no CTA by design — it is an argument, not a funnel — so the
-     single action it offers arrives only after the argument has finished
-     making itself: the mark has closed, the claim has come to rest, and the
-     film is holding still. Then this.
+      /* THE ONE THING YOU CAN DO. The page has no CTA by design — it is an
+     argument, not a funnel — so its single action arrives only once the
+     argument is over: the mark closed, the claim at rest, the film still.
 
-     Set as text, not as a filled block. The block was the loudest object on
-     the page by a distance — the only solid shape in a composition made of
-     marks and thin type — and it read as a product page's button dropped onto
-     the end of an essay. As a rule the same as the chrome's, in the same face
-     and tracking, it is legible as an action without claiming to be the point.
+     Set as text, not as a filled block: the block was the only solid shape in a
+     composition made of marks and thin type, and read as a product page's
+     button on the end of an essay. In Cormorant, the face the lockup opens
+     with, so the page closes in the voice it opened in rather than in the
+     chrome's mono, which is the register for labels and machinery. Sentence
+     case and untracked, so it cannot read as a second headline.
 
-     Set in Cormorant, which is the brand's own face and the one the lockup
-     above opens with — so the last thing on the page is in the same voice as
-     the first, rather than in the chrome's mono, which is the register the
-     page uses for labels and machinery. Sentence case, untracked: a tracked
-     uppercase line here would read as a second headline arguing with the
-     claim two lines above it.
+     No letter-spacing, so text-decoration hugs the glyphs and, not being
+     layout, appears on hover without moving anything. The arrow is an atomic
+     inline all three engines skip, so its hairline and the underline never
+     join.
 
-     No rule at rest. It carries none of the mono's letter-spacing now, so
-     text-decoration hugs the glyphs and there is no trailing space to throw
-     the rule off centre — and because text-decoration is not layout, the
-     underline can appear on hover without anything moving. The rule stops at
-     the words: the arrow is an atomic inline, which all three engines skip
-     rather than draw through, so the hairline under the type and the hairline
-     of the arrow never join into one long stroke.
-
-     Deliberately NOT .fade. The lockup's lines arrive through a mask wipe
-     because they are type resolving out of the field; this is not part of the
-     argument, it is what is offered once the argument is over, and a wipe read
-     as one more piece of choreography. It just rises and fades — see
-     floatCta(). */
-      /* opacity:0 because the value is entirely JS-driven — the CSS default of 1
-     made the link flash fully lit the instant the finale mounted. The
-     transition is gone with it: floatCta() rate-limits the arrival itself now,
-     on one clock with the rise, which the transition was tearing apart. */
+     NOT .fade: a mask wipe belongs to type resolving out of the field. This
+     rises and fades instead, in floatCta() — which owns the opacity (hence 0
+     here; the CSS default of 1 flashed the link lit as the finale mounted) and
+     rate-limits the arrival on one clock with the rise. */
       .cta {
         display: inline-block;
         padding: 0.55rem 0.3rem;
@@ -866,18 +703,12 @@
         outline: none;
       }
 
-      /* The arrow is DRAWN, not typed. None of the four faces this page ships
-     carries U+2192, so a typed arrow would fall out of the stack to whatever
-     the system serves as `serif` — a Times arrow, heavier and stubbier than
-     anything else on the line, next to Cormorant at weight 300. Drawn, it is
-     one hairline: non-scaling-stroke pins it to exactly 1px, the same 1px the
-     hover rule underneath it is drawn at, so the two read as the same
-     instrument. vertical-align:middle is the definition we want here — the
-     box's centre against the baseline plus half the parent's x-height — which
-     puts the shaft through the middle of the lowercase, and keeps the arrow
-     entirely above the baseline so it cannot deepen the line box.
-     pointer-events:none so the anchor, not the path, is what the cursor
-     finds. */
+      /* The arrow is DRAWN, not typed: no face this page ships carries U+2192,
+     so a typed arrow falls out of the stack to the system `serif` — a Times
+     arrow beside Cormorant at 300. non-scaling-stroke pins it to exactly 1px,
+     the same 1px the hover underline uses, so the two read as one instrument.
+     vertical-align:middle puts the shaft through the lowercase and keeps the
+     arrow off the baseline, so it cannot deepen the line box. */
       .cta .arw {
         width: 0.95em;
         height: 0.292em;
@@ -900,9 +731,8 @@
           serif;
         letter-spacing: -0.008em;
       }
-      /* The hinge. Small, tracked, grey — the same register as the corner marks,
-     so the verb reads as connective tissue between two statements rather than
-     as a third statement. */
+      /* The hinge. Small, tracked, grey — the corner marks' register, so the
+     verb reads as connective tissue rather than as a third statement. */
       .l2 {
         margin-top: 0.81rem;
         font:
@@ -917,29 +747,20 @@
       /* The claim. All-caps neo-grotesque, light, widely tracked, closed by a
      blinking terminal block instead of a period.
 
-     The block must not push the words off centre — the sentence is centred and
-     the cursor hangs off its right, exactly as a caret does at the end of a
-     line you have finished typing. That is what the text-indent buys:
+     The block must not push the words off centre — it hangs off the right, as a
+     caret does at the end of a line you have finished typing. The compensation
+     is cursor margin (.26) + cursor width (.60) + the text's own trailing
+     letter-space (.145) = 1.005em, exactly what the cursor would drag the line
+     left by, so the INK is centred rather than the line box. Tracking lives on
+     the inner span so the block cannot pick up a stray letter-space and break
+     that sum.
 
-       indent = cursor margin (.26) + cursor width (.60) + the text's own
-                trailing letter-space (.145) = 1.005em
-
-     which is precisely the distance the cursor would otherwise drag the line
-     left, so subtracting it back centres the INK rather than the line box.
-     Tracking lives on the inner span, not here, so the block can never pick up
-     a stray letter-space and break that sum.
-
-     It is a negative margin on the CURSOR and not a text-indent on the block,
-     because text-indent only ever applies to the first line. The moment the
-     claim wrapped — which it does at phone widths — the compensation landed on
-     the line without the cursor on it and the two lines were centred on axes
-     an em apart. The margin travels with the cursor, so it is correct on
-     whichever line the cursor ends up on. */
-      /* padding+margin for the same reason as .blk h1's descender fix above: the
-     caret is pulled OUTSIDE the line box by margin-right:-1.005em, and .fade's
-     mask clips to the border box, so at 320px the entire terminal block was
-     sliced off — 770 device px of ink, the sentence's full stop. The pair nets
-     to zero, so not one glyph moves. */
+     A negative margin on the CURSOR, not a text-indent on the block:
+     text-indent applies only to the first line, so once the claim wrapped — as
+     it does at phone widths — the two lines were centred an em apart. The
+     padding+margin pair is the descender fix again, the caret being pulled
+     outside a line box whose border box .fade's mask clips to; it nets to
+     zero. */
       .l3 {
         font:
           300 clamp(1.15rem, 2.8vw, 2.5rem)/1.25 Inter,
@@ -952,36 +773,26 @@
       .l3 .t {
         letter-spacing: 0.145em;
       }
-      /* ON A PHONE THE CLAIM IS AS BIG AS ONE LINE ALLOWS.
-     The desktop clamp's floor is 1.15rem, and on a narrow frame that is what
-     binds — the last words of the film set smaller than the sentence above
-     them. The ceiling here is the fit itself: measured, MACHINES THAT DECIDE
-     in Inter 300 with this tracking is 14.94 times the font-size wide, and the
-     lockup is 86vw, so 86 / 14.94 = 5.76vw is exactly the size at which it
-     fills the line — 5.6vw with a hair of slack, because a wrap here costs a
-     line of the film's last frame.
-
-     Set halfway between that ceiling and the 1.15rem floor it used to take,
-     which is where it reads: at the ceiling the claim outweighed the name
-     above it. The mean of the two rules rather than a third number, so it
-     still moves with the frame. 5.6vw stays in the min() as a hard ceiling:
-     below about 300px the rem floor is itself wider than the line, so the mean
-     of the two would wrap where the fit alone would not. The rem cap is only a
-     backstop against a very large root size. */
+      /* ON A PHONE THE CLAIM IS AS BIG AS ONE LINE ALLOWS. The desktop clamp's
+     1.15rem floor binds on a narrow frame, setting the film's last words
+     smaller than the sentence above them. The ceiling is the fit: MACHINES THAT
+     DECIDE in Inter 300 at this tracking is 14.94 times the font-size wide and
+     the lockup is 86vw, so 86 / 14.94 = 5.76vw fills the line — 5.6vw with a
+     hair of slack, a wrap here costing a line of the film's last frame. Set
+     halfway between that and the 1.15rem floor, where it reads; at the ceiling
+     the claim outweighed the name. 5.6vw stays a hard ceiling because below
+     ~300px the rem floor is itself wider than the line. */
       @media (max-width: 560px) {
         .l3 {
           font-size: min(2.2rem, 5.6vw, calc((1.15rem + 5.6vw) / 2));
         }
       }
-      /* An empty inline-block takes its baseline from its bottom margin edge, so
-     `vertical-align:baseline` seats it on the baseline. Taller than the caps
-     (.93 against a .727em cap height) and narrower than square: a terminal
-     cell is a standing rectangle, and a true square read as a dot.
-
-     Being taller than the caps means the baseline is the WRONG datum — sitting
-     on it, the block overhangs the cap line and reads high. The negative bottom
-     margin drops it by (.93 - .727) / 2 so the block's centre and the cap
-     band's centre coincide, which is where the eye actually looks. */
+      /* An empty inline-block takes its baseline from its bottom margin edge,
+     so `vertical-align:baseline` seats it there. Taller than the caps (.93
+     against a .727em cap height) and narrower than square — a terminal cell is
+     a standing rectangle, and a square read as a dot. Taller makes the baseline
+     the wrong datum, so the negative margin drops it by (.93 - .727) / 2 onto
+     the cap band's centre. */
       .l3 .cur {
         display: inline-block;
         vertical-align: baseline;
@@ -993,8 +804,8 @@
         background: var(--ink-live, var(--ink));
         animation: caret 1.06s step-end infinite;
       }
-      /* Bounded. A 2x22px block toggling forever was 97% of the closing screen's
-     remaining power draw, on the one screen the reader is meant to sit on. */
+      /* Bounded. A 2x22px block toggling forever was 97% of the closing
+     screen's remaining power draw, on the one screen the reader sits on. */
       .fin-b .cur {
         animation-iteration-count: 12;
       }
@@ -1012,21 +823,13 @@
         }
       }
 
-      /* THE FINALE'S TRANSITION — not the halftone resolve.
-     ------------------------------------------------------------------------
-     Every other section condenses its type out of the grid, because that is
-     the argument those sections make: the picture and the words on one
-     lattice. The ending is not an argument, it is a sign-off, and it wants to
-     arrive the way a title card arrives — softly. So the finale opts out.
-
-     Three things move together, in and out:
-       --rv  a mask that wipes up the line, revealing it from the baseline
-       --ex  a second mask, intersected, that erases it the same way
-       opacity, and a small translate, both driven alongside.
-
-     The masks are what keep it from reading as a plain CSS fade: the line
-     resolves and dissolves with a direction, bottom-up, in the same sense the
-     lockup is travelling. */
+      /* THE FINALE'S TRANSITION — not the halftone resolve. Every other section
+     condenses its type out of the grid, which is the argument those sections
+     make; the ending is a sign-off and arrives the way a title card does. --rv
+     wipes the line up from the baseline, --ex is a second mask, intersected,
+     that erases it the same way. The masks are what keep it from reading as a
+     plain CSS fade: it resolves and dissolves with a direction, bottom-up, in
+     the sense the lockup travels. */
       .fade {
         will-change: opacity, transform;
         -webkit-mask-image:
@@ -1055,24 +858,18 @@
         mask-composite: intersect;
       }
 
-      /* KINETIC TYPE, in this page's own grammar.
-     ------------------------------------------------------------------------
-     The first attempt slid each word up out of a mask. It worked, and it was
-     wrong: sliding is the default move of every motion-design template there
-     is, and nothing else on this page slides. Everything else here is a rigid
-     lattice of squares whose SIZE carries the image — so the type arrives that
-     way too. It is a halftone of itself that resolves.
+      /* KINETIC TYPE, in this page's own grammar. The first attempt slid each
+     word up out of a mask; it worked, and it was wrong — sliding is the default
+     move of every motion-design template there is, and nothing else on this
+     page slides. Everything else is a rigid lattice of squares whose SIZE
+     carries the image, so the type arrives that way too: a halftone of itself
+     that resolves.
 
-     Three mask layers, intersected:
-       1. vertical stripes of width --mk on a 12px pitch
-       2. horizontal stripes of width --mk on a 12px pitch
-          (1 n 2 = squares of --mk on the same 12px lattice as the field)
-       3. a soft sweep at --sw giving the reveal a direction
-
-     Growing --mk from 0 to 12px makes the letterforms condense out of the grid
-     and close up solid; shrinking it back disintegrates them into it. The 12px
-     pitch is the field's own cell size, so the type and the picture are
-     literally on the same grid. */
+     Three intersected layers: vertical and horizontal stripes of width --mk on
+     a 12px pitch, meeting as squares of --mk, plus a soft sweep at --sw giving
+     the reveal a direction. Growing --mk to 12px condenses the letterforms out
+     of the grid; shrinking it disintegrates them back. The 12px pitch is the
+     field's own cell size, so type and picture are literally on one grid. */
       .kin {
         -webkit-mask-image:
           linear-gradient(90deg, #000 var(--mk), transparent 0),
@@ -1169,11 +966,10 @@
       <div class="finale" id="finale">
         <div class="fin-a" id="finA"></div>
         <div class="fin-b" id="finB"></div>
-        <!-- tabindex="-1" because this whole layer is aria-hidden: it is a
-           rendered duplicate of #story, and a focusable control inside
-           aria-hidden content is a trap — reachable by keyboard, invisible to
-           a screen reader. The chrome's ABOUT link is the same destination and
-           is announced properly, so this one is for the mouse. -->
+        <!-- tabindex="-1" because this layer is aria-hidden: a focusable
+           control inside aria-hidden content is a trap, reachable by keyboard
+           and invisible to a screen reader. The chrome's ABOUT link is the same
+           destination, announced properly. -->
         <div class="fin-c" id="finC">
           <a class="cta" id="cta" href="/about.html" tabindex="-1"
             >join us<svg class="arw" viewBox="0 0 26 8" aria-hidden="true">
@@ -1184,11 +980,9 @@
     </div>
 
     <main class="story" id="story">
-      <!-- The six beats were six h1s and nothing else, so heading navigation
-           gave a screen-reader user six equal-rank siblings with no way to
-           tell the claim from the beats supporting it. One page-level h1, and
-           the beats demote to h2. #story is clipped, so nothing visible
-           moves. -->
+      <!-- Six h1s gave heading navigation six equal-rank siblings with no way
+           to tell the claim from the beats supporting it. One page-level h1,
+           beats demote to h2; #story is clipped, so nothing visible moves. -->
       <h1 class="sr">Predictive Text Labs — Machines that Decide</h1>
       <section data-key="DECIDE">
         <h2>
@@ -1196,10 +990,10 @@
           government and business.
         </h2>
       </section>
-      <!-- data-in / data-out are "start,length" in section-local time, and
-         override the defaults for this beat only. This one clears out
-         early and the next arrives quickly, because the gap between the
-         question and the answer was reading as a pause. -->
+      <!-- data-in / data-out are "start,length" in section-local time,
+         overriding the defaults for one beat. This one clears early and the
+         next arrives quickly: the gap between question and answer read as a
+         pause. -->
       <section data-key="WHEN" data-out="0.64,0.20">
         <h2>The question is not whether this future arrives, but when.</h2>
       </section>
@@ -1222,11 +1016,10 @@
           to decisions that matter.
         </h2>
       </section>
-      <!-- The finale is the one section set as a lockup rather than a sentence:
-         three registers, and two destinations. The name and the verb leave,
-         the claim stays. No period on the last line — a blinking terminal
-         block stands in for it, which is a full stop still waiting for the
-         next input. -->
+      <!-- The one section set as a lockup rather than a sentence: three
+         registers, two destinations. The name and the verb leave, the claim
+         stays. No period — a blinking terminal block stands in for it, a full
+         stop still waiting for the next input. -->
       <section data-key="DECIDE" data-finale>
         <h2>
           <span class="ln">Predictive Text Labs.</span>

--- a/index.html
+++ b/index.html
@@ -123,42 +123,23 @@
       }
 
       /* THE PALETTE — one colourway, and this is it.
-     ------------------------------------------------------------------------
-     Every colour on the page, including the two the shader resolves its 1-bit
-     output to, comes from here. The renderer is handed --field and --paper at
-     draw time, so the film and the type can never disagree about the ground
-     they are on. --field is a separate token from --ink because the film's
-     colour and the writing's colour are allowed to differ: the field is an
-     event in the picture, not a change of voice in the copy.
+     Every colour, including the two the shader resolves its 1-bit output to,
+     comes from here: the renderer is handed --field and --paper at draw time,
+     so the film and the type cannot disagree about the ground they are on.
+     --field is a separate token from --ink because the film's colour and the
+     writing's are allowed to differ — the field is an event in the picture,
+     not a change of voice in the copy. --tint is the mark at its DIMMEST, the
+     dim end of the black-body ramp the shader walks up to --field.
 
-     --wash is the defocus dome. It used to be a brightness() term, which only
-     works when the paper is at one end of the range: on a MID-TONE ground,
-     brightening the backdrop pushes the paper itself past white and paints a
-     visible bright dome over the page. So the dome is now a translucent sheet
-     of the paper colour laid over a plain blur — which is what "lower the
-     contrast of whatever is behind the copy" actually means, and it is correct
-     for any ground, dark, light or mid. */
-      /* THE FILM IS A DUOTONE, and the values are measured rather than
-     chosen: sampled off photographs of the page running, the ground is a deep
-     indigo (#111228, consistent across six frames) and the marks are a warm
-     cream (#F5E1BA at the arch's crown, #E4C198 through the mid limb). Cool
-     shadow against warm highlight is what makes it read as a surface catching
-     light from a warm bulb instead of as a diagram.
+     The ground is PITCH BLACK — the fact ptl-field.js points back here for. It
+     was indigo for a long time; the greys were re-matched to black by
+     LUMINANCE rather than by eye, so the type sits exactly where it sat:
+     5.77:1 for the chrome's --dim, 7.10:1 for the body's --mid, both clear AA.
 
-     --tint is the mark at its DIMMEST. The shader ramps the mark's hue from
-     it up to --field as the form brightens, which is a black-body ramp: a
-     filament is orange when it is cool and goes pale as it heats. That ramp
-     is the "iridescence" — a single flat mark colour cannot produce it.
-
-     The ground is PITCH BLACK. It was a deep indigo for a long time, sampled
-     off photographs of the thing running, and the greys were re-authored on it
-     — each carrying a little of the paper's own hue, because pure neutrals
-     read cold and dirty against blue-violet. With the blue gone they are
-     neutral again, matched to the old ones by LUMINANCE rather than by eye so
-     the type sits exactly where it sat: #8A8398 -> #868686, #9A93A6 -> #969696,
-     #ADA6B8 -> #A9A9A9, rule #33334D -> #353535. Contrast improves slightly on
-     the way, because black is darker than the indigo was — 5.77:1 for the
-     chrome's --dim and 7.10:1 for the body's --mid, both clear AA. */
+     --wash is the defocus dome: a translucent SHEET of the paper colour over a
+     plain blur, not a brightness() term. Brightening only works when the paper
+     is at one end of the range; on a mid-tone ground it paints a visible bright
+     dome over the page instead of lowering the contrast behind the copy. */
       :root {
         --paper: #000000;
         --ink: #f4eada;
@@ -423,8 +404,13 @@
           line-height: 1.62;
         }
       }
-      /* The page declares viewport-fit=cover, so on a notched phone in landscape
-     the bar would otherwise lay itself into the cutout it opted into. */
+      /* The page declares viewport-fit=cover, so on a notched phone the bar
+     would otherwise lay itself into the cutout it opted into.
+     AFTER the 560px block on purpose, and unconditional: on a landscape phone
+     (max-height matches, max-width does not) it beats that block on all three
+     sides — 2.4rem, not 1.2/1.5 — which is the frame the bar was retuned on.
+     Do NOT fold it into the base rule above; about.html's is folded and that
+     is not the same rule. */
       .chrome {
         padding-left: max(2.4rem, env(safe-area-inset-left));
         padding-right: max(2.4rem, env(safe-area-inset-right));

--- a/index.html
+++ b/index.html
@@ -159,17 +159,21 @@
      scroll-choreographed containers, which would leave a crawler, a link
      preview and a screen reader with no words at all. The copy lives here
      instead, as ordinary semantic HTML, and the script reads it out of the DOM;
-     the rendered version is aria-hidden so it is not announced twice. */
-      .story {
+     the rendered version is aria-hidden so it is not announced twice.
+
+     One recipe, two users: the copy itself, and the page h1 inside it that
+     stays hidden even when .no-js unhides the rest. */
+      .story,
+      .story .sr {
         position: absolute;
         width: 1px;
         height: 1px;
-        margin: -1px;
-        padding: 0;
-        border: 0;
         overflow: hidden;
         clip-path: inset(50%);
         white-space: nowrap;
+      }
+      .story {
+        margin: -1px;
       }
 
       .stage {
@@ -193,9 +197,6 @@
         inset: 0;
         z-index: 2;
         pointer-events: none;
-      }
-      .type a {
-        pointer-events: auto;
       }
       /* The LAYER is transparent to the pointer; the WORDS are not — otherwise
      the copy cannot be selected or copied. Only the text boxes take the pointer
@@ -315,7 +316,8 @@
       }
       /* On a phone, and on any short viewport, the form reaches the header and
      the bar is set over pure white cells. A scrim of the page's own ground,
-     only there.
+     only there. max-height too: a landscape phone is 844 wide, never matched,
+     and got the desktop bar — 87.7px, 22% of a 390-tall frame.
 
      FULL paper to 72%, not a partial scrim: --dim reads 5.03:1 on black and
      4.17:1 on white, so it survives both extremes and dies only on the
@@ -335,13 +337,8 @@
             transparent 100%
           );
         }
-      }
-      /* max-height too: a landscape phone is 844 wide, never matched, and got
-     the desktop bar — 87.7px, 22% of a 390-tall frame. */
-      @media (max-width: 560px), (max-height: 560px) {
         .chrome {
           padding: 1.5rem 1.2rem;
-          align-items: center;
         }
         .nav .count,
         .nav i {
@@ -802,12 +799,10 @@
         margin-bottom: -0.1015em;
         margin-right: -1.005em;
         background: var(--ink-live, var(--ink));
-        animation: caret 1.06s step-end infinite;
-      }
-      /* Bounded. A 2x22px block toggling forever was 97% of the closing
-     screen's remaining power draw, on the one screen the reader sits on. */
-      .fin-b .cur {
-        animation-iteration-count: 12;
+        /* Bounded, not infinite. A 2x22px block toggling forever was 97% of the
+       closing screen's remaining power draw, on the one screen the reader sits
+       on. */
+        animation: caret 1.06s step-end 12;
       }
       @keyframes caret {
         0% {
@@ -920,14 +915,6 @@
       .no-js .story section + section {
         margin-top: 4rem;
       }
-      .story .sr {
-        position: absolute;
-        width: 1px;
-        height: 1px;
-        overflow: hidden;
-        clip-path: inset(50%);
-        white-space: nowrap;
-      }
       .no-js .story h1,
       .no-js .story h2 {
         font:
@@ -984,7 +971,7 @@
            to tell the claim from the beats supporting it. One page-level h1,
            beats demote to h2; #story is clipped, so nothing visible moves. -->
       <h1 class="sr">Predictive Text Labs — Machines that Decide</h1>
-      <section data-key="DECIDE">
+      <section>
         <h2>
           In twenty years, machines will make most consequential decisions in
           government and business.
@@ -994,13 +981,13 @@
          overriding the defaults for one beat. This one clears early and the
          next arrives quickly: the gap between question and answer read as a
          pause. -->
-      <section data-key="WHEN" data-out="0.64,0.20">
+      <section data-out="0.64,0.20">
         <h2>The question is not whether this future arrives, but when.</h2>
       </section>
-      <section data-key="EARN" data-in="0.00,0.15">
+      <section data-in="0.00,0.15">
         <h2>How can we help machines earn this right to lead?</h2>
       </section>
-      <section data-key="COMMIT">
+      <section>
         <h2>
           A machine earns this right through a track record of committing scarce
           resources into the world.
@@ -1010,7 +997,7 @@
           Tomorrow's AI must know the cost of failure.
         </p>
       </section>
-      <section data-key="PRICE">
+      <section>
         <h2>
           Predictive Text Labs teaches machines to forecast so they can commit
           to decisions that matter.
@@ -1020,7 +1007,7 @@
          registers, two destinations. The name and the verb leave, the claim
          stays. No period — a blinking terminal block stands in for it, a full
          stop still waiting for the next input. -->
-      <section data-key="DECIDE" data-finale>
+      <section data-finale>
         <h2>
           <span class="ln">Predictive Text Labs.</span>
           <span class="ln">Builds</span>

--- a/index.html
+++ b/index.html
@@ -24,18 +24,6 @@
     <meta name="color-scheme" content="dark" />
     <meta name="format-detection" content="telephone=no" />
 
-    <!-- The palette switch, resolved in the HEAD so it lands before the first
-     paint. It used to sit with the other scripts at the end of the body, which
-     is after the browser is entitled to have painted the background once
-     already — long enough for ?v=2 to flash black before turning stone. Only
-     the attribute is set here; the stylesheet below reads it. -->
-    <script>
-      {
-        const v = new URLSearchParams(location.search).get("v");
-        if (v === "2" || v === "3" || v === "4")
-          document.documentElement.dataset.v = v;
-      }
-    </script>
     <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
     <link rel="icon" href="/favicon.ico" sizes="any" />
 
@@ -134,23 +122,14 @@
         font-display: block;
       }
 
-      /* THE PALETTE — four colourways, one switch.
+      /* THE PALETTE — one colourway, and this is it.
      ------------------------------------------------------------------------
      Every colour on the page, including the two the shader resolves its 1-bit
      output to, comes from here. The renderer is handed --field and --paper at
      draw time, so the film and the type can never disagree about the ground
-     they are on. Variation 1 is the default and has no query at all; 2, 3 and
-     4 are selected with ?v=, and ?v= anything else falls back to 1.
-
-       1  the original: white mark on black
-       2  inverted onto the old site's own paper (Tailwind stone-100), which
-          is warm — pure white would have read as a different brand
-       3  the same paper and the same black type as 2, with the blue confined
-          to the FIELD. That is why --field is a separate token from --ink:
-          the colour is an event in the film, not a change of voice in the
-          writing, and running the copy in it as well made the page read as
-          branded-blue rather than as a black-and-white page with one blue
-          thing moving on it.
+     they are on. --field is a separate token from --ink because the film's
+     colour and the writing's colour are allowed to differ: the field is an
+     event in the picture, not a change of voice in the copy.
 
      --wash is the defocus dome. It used to be a brightness() term, which only
      works when the paper is at one end of the range: on a MID-TONE ground,
@@ -159,7 +138,7 @@
      of the paper colour laid over a plain blur — which is what "lower the
      contrast of whatever is behind the copy" actually means, and it is correct
      for any ground, dark, light or mid. */
-      /* Variation 1 is a DUOTONE, and the values are measured rather than
+      /* THE FILM IS A DUOTONE, and the values are measured rather than
      chosen: sampled off photographs of the page running, the ground is a deep
      indigo (#111228, consistent across six frames) and the marks are a warm
      cream (#F5E1BA at the arch's crown, #E4C198 through the mid limb). Cool
@@ -192,117 +171,6 @@
         --wash: rgba(0, 0, 0, 0.62);
         --deep: rgba(0, 0, 0, 0.33);
         --tint: #c64a16;
-      }
-      /* stone-300. Warm and heavy enough that the type tones cannot be reused
-     from the dark variant — #6E6E6E is 4.1:1 on black and 2.6:1 here. These
-     are picked against this ground specifically. */
-      /* VARIATION 4 — the film with nothing added to it.
-     ------------------------------------------------------------------------
-     Same black ground and the same six beats, but strictly one bit: no drop
-     shadow, no warm ramp on the mark, no bloom or spill on the ground. Every
-     pixel in the frame is either the ink or the paper, which is what the
-     halftone claims to be and what variation 1 relaxes on purpose.
-
-     It is here to be the control. Variation 1's toning is an argument — that
-     the field reads as an emulsion catching light rather than as a diagram —
-     and an argument of that kind is only worth anything next to the thing it
-     is arguing against. --tint is set to the paper so that even the token is
-     a no-op; the shader is told separately, via tone, not to ramp at all.
-
-     The greys are variation 1's, which are already neutral and already
-     matched to this ground. */
-      :root[data-v="4"] {
-        --paper: #000000;
-        --ink: #ffffff;
-        --field: #ffffff;
-        --field-end: #ffffff;
-        --dim: #7c7c7c;
-        --mid: #8a8a8a;
-        --soft: #9e9e9e;
-        --rule: #333333;
-        --wash: rgba(0, 0, 0, 0.62);
-        --deep: rgba(0, 0, 0, 0.33);
-        --tint: #000000;
-      }
-      :root[data-v="2"] {
-        --paper: #d6d3d1;
-        --ink: #0c0a09;
-        --field: #0c0a09;
-        --field-end: #0c0a09;
-        --dim: #57534e;
-        --mid: #44403c;
-        --soft: #3b3735;
-        --rule: #9c9691;
-        --wash: rgba(214, 211, 209, 0.7);
-        --deep: rgba(214, 211, 209, 0.33);
-        /* The dim end of the mark. On paper the ramp runs the other way — a dark
-       mark on a light ground is DEEPER when it is dim, not warmer-brighter —
-       so this is a warm near-black that lifts to the flat ink as the form
-       brightens. Same mechanism, inverted ground. */
-        --tint: #3e301e;
-      }
-      /* taupe-300 — variation 2's step, in variation 3's colour.
-     ------------------------------------------------------------------------
-     This ground was taupe-400 for a while, a full step heavier, on the
-     argument that the blue takes a deeper paper best: the deeper the ground,
-     the more the halftone reads as a printed screen rather than a glow. The
-     glow was real. What it cost was the picture. A genuinely mid ground caps
-     the page at about 7.8:1 even with near-black ink, and it caps the FILM
-     harder than it caps the type — the blue managed 3.97:1 against that
-     paper and the tint, which owns the whole floor of the frame, only
-     1.40:1. The crown measured 0.845 modulation and the bottom third
-     dissolved into the ground rather than standing in front of it. Here the
-     same two inks measure 6.79:1 and 2.40:1, and the crown 0.912. The lower
-     limbs stay graphic all the way down, which is what the light climbing
-     the frame was for.
-
-     TAUPE, not stone, and the whole block moves together — the temperature
-     is now the only thing separating this ground from variation 2's, so it
-     has to carry the distinction on its own. Taupe sits at hue ~41 against
-     stone's ~56 — redder, and at about one and a half times the chroma — so
-     a taupe ground under stone ink reads as two different warms arguing
-     rather than one. The greys are variation 2's scale held at their own
-     OKLCH lightness and re-authored with taupe's hue and chroma: the tonal
-     structure that was tuned against a 300 ground is preserved exactly and
-     only the temperature moves. Every ratio holds to within 0.04 of a point
-     — ink 13.26 -> 13.27, --mid 6.90 -> 6.90, --dim 5.12 -> 5.16, the blue
-     6.79 -> 6.79.
-
-     The chroma is a judgement and not a lookup. Stone's own chroma nearly
-     vanishes at the 300 step — 0.004, against taupe-400's 0.014 — so taking
-     this paper from the scale ratio alone gives #D8D2D0, which is stone with
-     a rumour of warmth and is not taupe at all. It sits at 0.010 instead,
-     near the midpoint: unmistakably the 400's own colour a step lighter, and
-     short of the blush that holding the full 0.014 turns into this close to
-     white. */
-      :root[data-v="3"] {
-        /* --field-end is where the mark ARRIVES. The blue is the state of the
-       argument at the top of the page, not a brand colour, so it resolves
-       to the same ink the type is set in by the time the film closes.
-       taupe-950 and stone-950 are the same hex, so the ink is unchanged.
-
-       AND THE BLUE IS A PIGMENT, NOT A DARK. It was #0000A0, which is not a
-       saturated blue — it is a dull one, dimmed by taking blue away. On a
-       light ground the useful trick is the opposite: blue carries only 0.0722
-       of the luminance, so it can be run almost to the top of its channel and
-       still land nearly as dark. #0000E0 is two thirds more chromatic than
-       #0000A0 and measures 0.918 modulation at the crown against its 0.961 —
-       four percent of the contrast, for an ink that reads as ink. */
-        --paper: #dad2cf;
-        --ink: #0c0a09;
-        --field: #0000e0;
-        --field-end: #0c0a09;
-        --dim: #5b514e;
-        --mid: #473f3c;
-        --soft: #3d3634;
-        --rule: #a09490;
-        --wash: rgba(218, 210, 207, 0.72);
-        --deep: rgba(218, 210, 207, 0.33);
-        /* NO --tint. The blue is the only variation that runs the film
-       strictly one bit on paper — see TONE — so the ramp, the ground's haze
-       and everything else that reads a tint are all multiplied out. A token
-       that names a colour nothing can use is a lie in the palette, and the
-       renderer falls back to the paper, which makes the term a no-op. */
       }
 
       * {
@@ -510,11 +378,11 @@
      82% scrim manufactures. Measured, 96.7% of ABOUT's core pixels fell below
      3:1 at the worst beat, median 1.41:1; with the scrim removed entirely,
      6.1%. It was the cause, not the cure, for ~2 viewport-heights of scroll on
-     every phone and every variant.
+     every phone.
 
      Full paper to 72% instead. The type sits 29-60% down an 83px bar, so this
      covers both wordmark lines and the link and still fades out at the bar's
-     bottom edge. Built from --paper, so it lands on all three variants. */
+     bottom edge. Built from --paper, so it is the page's own ground. */
       @media (max-width: 560px), (max-height: 560px) {
         .chrome::before {
           content: "";
@@ -586,18 +454,13 @@
      frame, starting at the mark's own centre.
 
      Not in the shader, though it was built there first — as a depth term
-     inside the mark's own feather. Two reasons it is here instead. That
-     feather is switched off entirely on variation 4, which is one bit by
-     contract, so the control would have been the variant without the effect;
-     and softening the MARK is the trade this page refuses everywhere else,
-     while softening the FRAME leaves every mark the shape it was drawn.
+     inside the mark's own feather. It is here instead because softening the
+     MARK is the trade this page refuses everywhere else, while softening the
+     FRAME leaves every mark the shape it was drawn.
 
      ON THE FILM'S OWN CLOCK. --resolved is the number the type resolves on,
      published by ptl-page.js; at the close it is 1 and this is gone. The last
-     frame is sharp to the floor, which is the point of the last frame.
-
-     The ramp is a token, not black paint: on paper the ground deepening is the
-     paper, or the bottom of the frame would go to soot on a light variation. */
+     frame is sharp to the floor, which is the point of the last frame. */
       /* PHONE ONLY. On a wide frame the mark keeps the upper two thirds and the
      copy has the floor, so there is no depth to describe down there — the
      bottom of the frame is where the argument is written, and blurring it
@@ -641,12 +504,12 @@
       /* saturate(0) so the defocus carries VALUE and not HUE. The wash is already
      the paper colour, but it is translucent on purpose — a defocus, not an
      eraser — and the ~28% of the field still showing through arrives with its
-     own colour. On variation 3 that is blue, so the dome behind the copy came
-     out lavender: a third colour, on a page that has two. Desaturating the
-     backdrop first means what bleeds through is only light and dark, and the
-     dome reads as the paper defocused. Measured: haze chroma 17 -> 8, against
-     the paper's own 10. A no-op on the other two variations, whose ink is
-     already neutral, so it does not need scoping to v3. */
+     own colour. That colour is warm — --field is a cream and --tint an orange
+     — so without this the dome behind the copy comes out tinted: a third
+     colour, on a page that has two. Desaturating the backdrop first means what
+     bleeds through is only light and dark, and the dome reads as the paper
+     defocused. NOT a no-op, and not removable: it changes what is drawn on
+     every frame the dome is over the field. */
       .veil {
         position: absolute;
         inset: 0;
@@ -1305,7 +1168,7 @@
       <span class="wm">PREDICTIVE <br />TEXT LABS</span>
       <nav class="nav">
         <span class="count"><b id="bn">01</b> / <span id="bt">06</span></span
-        ><i></i><a id="about" href="/about.html">ABOUT</a>
+        ><i></i><a href="/about.html">ABOUT</a>
       </nav>
     </header>
 
@@ -1387,35 +1250,6 @@
       </section>
     </main>
 
-    <script>
-      /* The rest of the switch, which needs the stylesheet parsed and the body
-     present. Both the browser chrome and the link out are derived from the
-     resolved palette rather than restated: the hexes live in one place. */
-      {
-        const paper = getComputedStyle(document.documentElement)
-          .getPropertyValue("--paper")
-          .trim();
-        const n = paper.replace("#", "");
-        const [r, g, b] = [0, 2, 4].map(
-          (i) => parseInt(n.slice(i, i + 2), 16) / 255,
-        );
-        document.querySelector("meta[name=theme-color]").content = paper;
-        /* Which end of the range the paper sits at is what `color-scheme` is for —
-       it is what the scrollbar and any UA widget are drawn against. Variations
-       2 and 3 are light grounds; announcing them as dark drew a dark scrollbar
-       down the side of a stone page. */
-        document.querySelector("meta[name=color-scheme]").content =
-          0.2126 * r + 0.7152 * g + 0.0722 * b > 0.5 ? "light" : "dark";
-
-        /* Carry the variation across to the about page, so following the link does
-       not silently drop you back into variation 1. */
-        const v = document.documentElement.dataset.v;
-        if (v)
-          for (const id of ["about", "cta"]) {
-            document.getElementById(id).href = "/about.html?v=" + v;
-          }
-      }
-    </script>
     <script src="/src/ptl-field.js"></script>
     <script src="/src/ptl-page.js"></script>
   </body>

--- a/src/ptl-field.js
+++ b/src/ptl-field.js
@@ -8,17 +8,17 @@
    what reads cheap. Area proportional to luminance means sqrt() on the side;
    every pixel is still pure black or pure white.
 
-   Three treatments share that output stage: FORM, one abstract form in screen
-   space, no world and no camera; ARCH, raymarched concrete flying past; TYPE,
-   Cormorant rendered to a texture and halftoned on the same grid.
+   FORM is what feeds that output stage, and all that does: one abstract form
+   in screen space, no world and no camera. Raymarched geometry and halftoned
+   type were built against it and lost, and went with the switch that chose
+   between them.
 
-   Drawn rather than filmed, for exact art direction (a near mass is an unlit
-   silhouette because RANGE says so) and zero scroll latency — a video scrub
-   measured 90ms median, spiking past 600ms.
+   Drawn rather than filmed, for exact art direction and zero scroll latency —
+   a video scrub measured 90ms median, spiking past 600ms.
 
    USAGE
-     const f = PTLField.mount(canvas, { mode: 'form' });
-     f.draw(0.42, { section: 2, cell: 12 });
+     const f = PTLField.mount(canvas);
+     f.draw(0.42, { cell: 12 });
    ========================================================================== */
 (function (root) {
   'use strict';
@@ -49,15 +49,10 @@
   out vec4 fragColor;
 
   uniform vec2      uRes;
-  uniform float     uT;         // 0..1 progress through this section
   uniform float     uCell;      // grid cell size in device px
   uniform float     uGap;       // black gutter between cells
   uniform float     uGain;
-  uniform int       uMode;      // 0 FORM  1 ARCH  2 TYPE
-  uniform int       uSection;   // 0..5
   uniform float     uG;         // 0..1 across the WHOLE page — FORM runs on this
-  uniform sampler2D uTex;       // TYPE only
-  uniform float     uFov;
   uniform vec3      uInk;       // the mark, at the top of the page
   uniform vec3      uInk2;     // the mark, at the bottom of it
   uniform vec3      uPaper;     // the ground
@@ -260,101 +255,8 @@
     return max(ring, lat) * clear;
   }
 
-  /* ---- ARCH ----------------------------------------------------------------
-     The storyboard's world, raymarched. Kept whole so the three treatments are
-     a fair comparison rather than one of them a sketch.                       */
-  float sdBox(vec3 p, vec3 b){
-    vec3 q = abs(p) - b;
-    return length(max(q, 0.0)) + min(max(q.x, max(q.y, q.z)), 0.0);
-  }
-
-  float map(vec3 p){
-    float d = 1e9;
-    /* Floating, never standing — unbounded void, no ground. It pays
-       compositionally: the masses have visible bottom edges converging toward
-       the horizon, leaving a black wedge along the frame's floor for type. */
-    vec3 q = p;
-    q.z = mod(q.z + 13.0, 26.0) - 13.0;
-    float sway = float(uSection) * 1.7;
-    d = min(d, sdBox(q - vec3(-21.0 - sway, 11.0, 0.0), vec3(2.6, 15.0, 2.6)));
-    d = min(d, sdBox(q - vec3( 21.0 + sway, 11.0, 0.0), vec3(2.6, 15.0, 2.6)));
-
-    vec3 g = p - vec3(0.0, 6.0, 168.0);
-    d = min(d, sdBox(g - vec3(-8.0,  0.0, 0.0), vec3(1.6, 12.0, 1.6)));
-    d = min(d, sdBox(g - vec3( 8.0,  0.0, 0.0), vec3(1.6, 12.0, 1.6)));
-    d = min(d, sdBox(g - vec3( 0.0, 13.4, 0.0), vec3(9.9, 1.5, 1.6)));
-    return d;
-  }
-
-  /* Nothing is lit closer than NEAR, so a mass arriving at the lens goes to
-     silhouette rather than to a lit grey slab. */
-  float range(float t){
-    return smoothstep(30.0, 74.0, t) * (1.0 - smoothstep(150.0, 260.0, t));
-  }
-
-  /* ONE MARK'S SHADOW, and the only place the metric is argued. p is relative
-     to that mark's centre, in cell units.
-
-     Not Chebyshev: the metric whose circles ARE squares gave every mark a
-     square halo whose corners met across a cell in hard rectangular patches,
-     worse the more blur. Distance to a BOX is Euclidean outside and therefore
-     round at the corners, at the same cost. A wide blur loses a square anyway,
-     so the metric follows the blur — hug the box while it is tight, go radial
-     as it grows past.
-
-     ZERO SPREAD, ALL BLUR, SCALED WITH THE MARK: sg is proportional with no
-     constant term. Spread grows the shape before blurring, which is a plateau,
-     and a floor would hand a one-pixel mark a fixed halo and haze over the
-     falloff, which is nothing but small marks. */
-  float castShadow(vec2 p, float e, float sg){
-    float dBox = length(max(abs(p) - e, vec2(0.0)));
-    float dRad = max(length(p) - e, 0.0);
-    float rnd  = clamp(sg / max(e, 1e-4), 0.0, 0.55);
-    return exp(-mix(dBox, dRad, rnd) / sg);
-  }
-
-  float arch(vec2 uv, float halfH, float t){
-    vec3 ro = vec3(0.0, 0.0, t * 125.0);
-    /* A shifted lens — the architectural photographer's rising front. Parks the
-       vanishing point above centre so the lower frame stays black. */
-    vec3 rd = normalize(vec3((uv - vec2(0.0, halfH * 0.50)) * uFov, 1.0));
-
-    float d, k = 0.0;
-    bool hit = false;
-    for (int i = 0; i < 96; i++){
-      d = map(ro + rd * k);
-      if (d < 0.012 * k){ hit = true; break; }
-      k += d * 0.85;
-      if (k > 260.0) break;
-    }
-    if (!hit) return 0.0;
-
-    vec3 p = ro + rd * k;
-    vec2 e = vec2(0.02, 0.0);
-    vec3 n = normalize(vec3(map(p + e.xyy) - map(p - e.xyy),
-                            map(p + e.yxy) - map(p - e.yxy),
-                            map(p + e.yyx) - map(p - e.yyx)));
-    vec3 L = normalize(vec3(0.62, 0.16, 0.77));
-    float lam = pow(max(dot(n, L), 0.0), 1.5);
-    float rim = pow(1.0 - abs(dot(n, rd)), 5.0);
-    return (lam * 0.95 + rim * 0.30) * range(k);
-  }
-
-  /* ---- TYPE ----------------------------------------------------------------
-     The word as the picture: Cormorant white on black, displaced by a warp that
-     eases out as the section resolves, so it arrives out of distortion rather
-     than fading in. Same grid, same marks, different subject.                 */
-  float typeField(vec2 uv, float t){
-    float ease = pow(1.0 - clamp(t, 0.0, 1.0), 1.7);
-    vec2 p = uv;
-    p /= mix(1.55, 1.22, smoothstep(0.0, 0.85, t));  // settles out of a push-in
-    p.y -= 0.34;   // sits high, so the headline below it stays on clean black
-    p.x += sin(p.y * 5.2 + ease * 7.0) * 0.10 * ease;
-    p.y += sin(p.x * 3.1) * 0.03 * ease;
-    vec2 tc = p * vec2(0.5, -0.5) + 0.5;
-    if (tc.x < 0.0 || tc.x > 1.0 || tc.y < 0.0 || tc.y > 1.0) return 0.0;
-    return texture(uTex, tc).r;
-  }
+  /* ---- THE MARKS -----------------------------------------------------------
+     One sample per cell, the mark it is drawn as, and that mark's shadow.    */
 
   /* THE MARK ANY GIVEN CELL CARRIES, in cell units. Out of main because a
      shadow is cast by a MARK, and the marks falling on a fragment are mostly
@@ -369,11 +271,7 @@
      evaluated. A halftone has exactly one sample per cell by definition, and
      the whole frame — marks, shadows, ground — is built from this lattice. */
   float formAt(vec2 id){
-    float halfH = halfHOf();
-    vec2  uvc   = cellUv(id);
-    float l = uMode == 0 ? form(uvc, uG)
-            : uMode == 1 ? arch(uvc, halfH, uT)
-                         : typeField(uvc, uT);
+    float l = form(cellUv(id), uG);
     /* Cut the tail. A near-constant 2% over a large area renders as a perfectly
        regular lattice of isolated marks — wallpaper across the frame and
        through the headline. This dim carries no form, so it is off, not dim. */
@@ -409,6 +307,27 @@
   /* ...and the mark a cell's texel gets drawn as, in cell units. */
   float markOf(vec3 t){
     return sqrt(clamp(decLum(t.rg), 0.0, 1.0)) * (1.0 - uGap) * decBrt(t.b);
+  }
+
+  /* ONE MARK'S SHADOW, and the only place the metric is argued. p is relative
+     to that mark's centre, in cell units.
+
+     Not Chebyshev: the metric whose circles ARE squares gave every mark a
+     square halo whose corners met across a cell in hard rectangular patches,
+     worse the more blur. Distance to a BOX is Euclidean outside and therefore
+     round at the corners, at the same cost. A wide blur loses a square anyway,
+     so the metric follows the blur — hug the box while it is tight, go radial
+     as it grows past.
+
+     ZERO SPREAD, ALL BLUR, SCALED WITH THE MARK: sg is proportional with no
+     constant term. Spread grows the shape before blurring, which is a plateau,
+     and a floor would hand a one-pixel mark a fixed halo and haze over the
+     falloff, which is nothing but small marks. */
+  float castShadow(vec2 p, float e, float sg){
+    float dBox = length(max(abs(p) - e, vec2(0.0)));
+    float dRad = max(length(p) - e, 0.0);
+    float rnd  = clamp(sg / max(e, 1e-4), 0.0, 0.55);
+    return exp(-mix(dBox, dRad, rnd) / sg);
   }
 
   void main(){
@@ -642,10 +561,7 @@
     return s;
   }
 
-  const MODES = { form: 0, arch: 1, type: 2 };
-
-  function mount(canvas, opt) {
-    opt = opt || {};
+  function mount(canvas) {
     const gl = canvas.getContext('webgl2', { antialias: false, alpha: false });
     if (!gl) return null;
 
@@ -654,7 +570,7 @@
        the browser never offers to restore at all, and a page whose entire
        picture is one shader would stay blank for the session while the type
        kept choreographing over nothing. */
-    let prog = null, u = {}, tex = null, drawn = null, lost = false;
+    let prog = null, u = {}, lost = false;
     /* The lattice pass and its target: one texel per cell plus a cell of
        border. lw/lh cache its size the way w/h cache the canvas's. */
     let latProg = null, ul = {}, latTex = null, fbo = null, lw = 0, lh = 0;
@@ -705,7 +621,6 @@
       if (!gl.isContextLost()) {          // else: two INVALID_OPERATIONs per restore
         if (prog) gl.deleteProgram(prog);
         if (latProg) gl.deleteProgram(latProg);
-        if (tex) gl.deleteTexture(tex);
         if (latTex) gl.deleteTexture(latTex);
         if (fbo) gl.deleteFramebuffer(fbo);
       }
@@ -729,17 +644,7 @@
                               gl.TEXTURE_2D, latTex, 0);
       gl.bindFramebuffer(gl.FRAMEBUFFER, null);
       lw = lh = 0;                      // and the lattice needs re-sizing
-
-      tex = gl.createTexture();
-      gl.bindTexture(gl.TEXTURE_2D, tex);
-      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE,
-                    new Uint8Array([0, 0, 0, 255]));
-      drawn = null;                     // the TYPE texture went with the context
-      w = h = 0;                        // and so did the viewport
+      w = h = 0;                        // the viewport went with the context too
     }
     /* Every caller reads this as "a field, or null" and branches once. The
        restore path honours that; the FIRST build did not, so a driver that took
@@ -766,31 +671,6 @@
       }
     });
 
-    /* The TYPE texture. Drawn on a 2D canvas rather than shaped in the shader
-       because it has to be Cormorant — the mandated face — and an SDF cannot be
-       a typeface. Redrawn only when the word changes. */
-    const pad = document.createElement('canvas');
-    function setWord(word) {
-      if (word === drawn) return;
-      drawn = word;
-      const W = 2048, H = 1152;
-      pad.width = W; pad.height = H;
-      const c = pad.getContext('2d');
-      c.fillStyle = '#000'; c.fillRect(0, 0, W, H);
-      c.fillStyle = '#fff';
-      c.textAlign = 'center'; c.textBaseline = 'middle';
-      /* Overflow the frame on purpose — the reference letterforms are cropped
-         hard by the edges, which is what gives a thin serif weight at scale. */
-      let size = 520;
-      c.font = `300 ${size}px Cormorant, serif`;
-      const w0 = c.measureText(word).width;
-      if (w0 > 0) size = Math.min(820, size * (W * 1.06 / w0));
-      c.font = `300 ${size}px Cormorant, serif`;
-      c.fillText(word, W / 2, H / 2);
-      gl.bindTexture(gl.TEXTURE_2D, tex);
-      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, pad);
-    }
-
     function size(dpr) {
       const nw = Math.round(canvas.clientWidth * dpr);
       const nh = Math.round(canvas.clientHeight * dpr);
@@ -802,19 +682,14 @@
     /* Both programs read the same picture, so both take the same uniforms —
        each handed its OWN location map, because a location belongs to a program
        and using one against the other silently writes nothing. */
-    function feed(p, uu, t, o, cell, mode) {
+    function feed(p, uu, t, o, cell) {
       gl.useProgram(p);
-      gl.uniform1i(uu.uTex, 0);
-      gl.uniform1i(uu.uLat, 1);
+      gl.uniform1i(uu.uLat, 0);
       gl.uniform2f(uu.uRes, w, h);
-      gl.uniform1f(uu.uT, t);
       gl.uniform1f(uu.uG, o.g != null ? o.g : t);
       gl.uniform1f(uu.uCell, cell);
       gl.uniform1f(uu.uGap, o.gap != null ? o.gap : 0.12);
       gl.uniform1f(uu.uGain, o.gain != null ? o.gain : 1.0);
-      gl.uniform1i(uu.uMode, mode);
-      gl.uniform1i(uu.uSection, o.section || 0);
-      gl.uniform1f(uu.uFov, o.fov != null ? o.fov : 0.70);
       const ink = o.ink || [1, 1, 1], paper = o.paper || [0, 0, 0];
       const ink2 = o.ink2 || ink;
       gl.uniform3f(uu.uInk, ink[0], ink[1], ink[2]);
@@ -843,8 +718,6 @@
       const dpr = Math.min(root.devicePixelRatio || 1, 2);
       const cell = (o.cell != null ? o.cell : 12) * dpr;
       size(dpr);
-      const mode = MODES[o.mode || opt.mode] || 0;
-      if (mode === 2 && o.word) setWord(o.word);
 
       /* One texel per cell, plus the cell of border cellAt() relies on. */
       const nw = Math.ceil(w / cell) + 2, nh = Math.ceil(h / cell) + 2;
@@ -856,27 +729,25 @@
       }
 
       gl.activeTexture(gl.TEXTURE0);
-      gl.bindTexture(gl.TEXTURE_2D, tex);
-      gl.activeTexture(gl.TEXTURE1);
       gl.bindTexture(gl.TEXTURE_2D, latTex);
 
       /* PASS ONE: the picture, once per cell. */
       gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
       gl.viewport(0, 0, lw, lh);
-      feed(latProg, ul, t, o, cell, mode);
+      feed(latProg, ul, t, o, cell);
       gl.drawArrays(gl.TRIANGLES, 0, 3);
 
       /* PASS TWO: the frame, which now only has to read it. */
       gl.bindFramebuffer(gl.FRAMEBUFFER, null);
       gl.viewport(0, 0, w, h);
-      feed(prog, u, t, o, cell, mode);
+      feed(prog, u, t, o, cell);
       gl.drawArrays(gl.TRIANGLES, 0, 3);
     }
 
     /* isLost is the RECOVERABLE half of isDead: draw() returns immediately for
        both, but the page needs them apart — dead is terminal, lost is where it
        stops asking UNTIL the restore event, its cue to start again. */
-    return { draw, setWord, gl, canvas, isDead: () => dead, isLost: () => lost };
+    return { draw, gl, canvas, isDead: () => dead, isLost: () => lost };
   }
 
   root.PTLField = { mount, CLOSE };

--- a/src/ptl-field.js
+++ b/src/ptl-field.js
@@ -83,11 +83,6 @@
   uniform vec3      uInk2;     // the mark, at the bottom of it
   uniform vec3      uPaper;     // the ground
   uniform vec3      uTint;      // the mark at its DIMMEST, and the ground's bloom
-  uniform float     uShadow;    // 1 = the mark casts one, 0 = it does not
-  uniform float     uTone;      // 1 = the film is toned, 0 = strictly 1-bit
-  /* 1 = the ground is PAPER, 0 = it is a room. Derived from the paper's own
-     luminance by the page, so a light palette gets it without being asked. */
-  uniform float     uPrint;
   uniform vec2      uMouse;     // pointer, in the same uv space as the field
   uniform float     uAct;       // 0..1 — how much the pointer is allowed to act
   uniform float     uTime;      // seconds — the ambient clock, which scroll speeds up
@@ -627,34 +622,6 @@
        square; only the light around them is not. */
     float d = max(f.x, f.y);
     float e = markOf(C[4]);
-    /* THE STROKE HAS AN EDGE ON PAPER, AND THE DARK VARIANT DOES NOT WANT ONE.
-       ------------------------------------------------------------------------
-       Everything above this line is about colour, and none of it could fix
-       what the pale variants were being accused of. Measured across the arch's
-       crown, every square's interior is EXACTLY the ink — rgb(0,0,224) at every
-       step of a cut through the band — while the cell average runs 170 -> 45 ->
-       160. So nothing radiates: the ink is one colour the whole way across, and
-       what falls off from the spine to either side is the mark's SIZE. A
-       halftone of a soft-edged stroke is a glow, because that is what a
-       shrinking dot means.
-
-       On black that is exactly right — a smaller mark is less light, and light
-       does fall off. On paper it is wrong twice over: less ink is not a dimmer
-       stroke, it is a thinner one, and a printed stroke has a boundary. So the
-       tone response gets a contrast curve here and the band gets an edge,
-       which leaves the vertical ramp as the only gradient in the frame — the
-       one that is supposed to be read.
-
-       Measured on the same cut, the band's coverage was 33 28 53 80 75 75 82 71
-       53 30 8 per cell and is now 0 33 75 75 75 75 75 75 78 53 0 — six cells of
-       transition down to two, with a flat interior. 0.26/0.58: tighter than
-       this and the boundary starts to show the cell grid as a staircase, wider
-       and the glow comes back.
-
-       On e rather than on the form, so the GROUND keeps the smooth field: the
-       lattice's own structure and the ambient are solved off lumG and are not
-       part of this. */
-    e = mix(e, 0.90 * smoothstep(0.26, 0.58, e / 0.90), uPrint);
     /* A DROP SHADOW, WHICH IS AN OUTSIDE-ONLY THING.
        ------------------------------------------------------------------------
        The mark stays a flat, hard square. Blurring the mark ITSELF looks
@@ -728,17 +695,11 @@
        half a cell, so one device pixel is 2/uCell of it. */
     /* The reflection is NOT here, and it was: a depth term inside this feather
        softened the mark itself toward the floor of the frame. It is a layer
-       over the canvas instead — .deep in the page — because a feather cannot
-       exist on variation 4, where uTone takes this to the floor by contract,
-       and an effect the one-bit control cannot have is an effect the control
-       cannot control for. */
-    float wSoft = max(e * mix(0.20, 0.02, resolveU), 1.0 / uCell);
-    /* Variation 4 has no feather either. The original mark was a hard step()
-       and the softness is one of the things that variation exists to control
-       for, so uTone takes it to the floor: a razor border, correctly sampled.
-       Not a literal step(), because that aliases and crawls as the field
-       breathes — this is the same edge without the crawl. */
-    float w     = mix(1.0 / uCell, wSoft, uTone);
+       over the canvas instead — .deep in the page — because softening the MARK
+       is the one trade this film refuses, while softening the FRAME leaves
+       every mark the shape it was drawn. Mirror of the .deep note in
+       index.html; keep the two in step. */
+    float w     = max(e * mix(0.20, 0.02, resolveU), 1.0 / uCell);
     /* GATED AT ZERO. In an EMPTY cell e is 0, so w is 0 and this would be
        smoothstep(0, 0, d) — spec-undefined for edge0 >= edge1, and on the usual
        lowering saturate(0/0) gives 0, i.e. mark = 1. It needs d == 0, which
@@ -803,36 +764,28 @@
        at distance three that arrives. Three cell-units out the exponential is
        at 5% for the largest mark on the page and immeasurable for any smaller
        one, and it is the max of nine, so a term that small is buried by its
-       neighbours. The 84% step is gone and nothing takes its place.
-
-       uShadow gates the whole loop, which is the pale variants' win: they pay
-       for one markOf instead of nine. The shadow belongs to the indigo variant
-       only — on the two light grounds the mark is DARK, so its shadow is dark
-       too, and a dark halo on light paper is not a mark catching light, it is a
-       smudge. The point of the thing is a lit emulsion, and only a dark ground
-       reads that way. */
+       neighbours. The 84% step is gone and nothing takes its place. */
     float shade = 0.0;
-    if (uShadow > 0.001){
-      for (int j = -1; j <= 1; j++){
-        for (int i = -1; i <= 1; i++){
-          vec2  off = vec2(float(i), float(j));
-          /* One cell is TWO units of gs, so the neighbour's centre sits at
-             2*off and the point handed to castShadow is gs measured from it. */
-          float en  = markOf(C[(j + 1) * 3 + (i + 1)]);
-          float sgn = mix(0.80 * en, 0.06 * en, resolveU) + 1e-4;
-          shade = max(shade, castShadow(gs - 2.0 * off, en, sgn)
-                             * smoothstep(0.0, 0.02, en));
-        }
+    for (int j = -1; j <= 1; j++){
+      for (int i = -1; i <= 1; i++){
+        vec2  off = vec2(float(i), float(j));
+        /* One cell is TWO units of gs, so the neighbour's centre sits at
+           2*off and the point handed to castShadow is gs measured from it. */
+        float en  = markOf(C[(j + 1) * 3 + (i + 1)]);
+        float sgn = mix(0.80 * en, 0.06 * en, resolveU) + 1e-4;
+        shade = max(shade, castShadow(gs - 2.0 * off, en, sgn)
+                           * smoothstep(0.0, 0.02, en));
       }
-      /* AND IT LEAVES ENTIRELY. Tightening sg alone takes the shadow to
-         0.06e, which is small but still 90% opaque against the mark's own
-         edge — a dark seam a pixel or two wide around every square, which is a
-         shadow, and the last frame is meant to have none. Multiplying it out
-         makes the end state arithmetically shadowless rather than nearly so,
-         and because sg tightens on the same clock it sharpens as it fades
-         rather than dissolving in place. */
-      shade *= 0.90 * uShadow * (1.0 - resolveU);
     }
+    /* AND IT LEAVES ENTIRELY. Tightening sg alone takes the shadow to
+       0.06e, which is small but still 90% opaque against the mark's own
+       edge — a dark seam a pixel or two wide around every square, which is a
+       shadow, and the last frame is meant to have none. Multiplying it out
+       makes the end state arithmetically shadowless rather than nearly so,
+       and because sg tightens on the same clock it sharpens as it fades
+       rather than dissolving in place. (1.0 - resolveU) is the resolve clock,
+       not a switch: without it the last frame keeps its shadow. */
+    shade *= 0.90 * (1.0 - resolveU);
 
     float cover = max(mark, shade);
 
@@ -841,8 +794,10 @@
        renderer's.
 
        The ink may travel across the page, though. Where uInk2 differs from
-       uInk the mark bleeds from one to the other as you scroll, which is
-       how the blue variation resolves to black by the last frame.
+       uInk the mark bleeds from one to the other as you scroll. They DO
+       differ here — uInk is the cream --field, uInk2 the white --field-end —
+       so this travel is live and the mix at the foot of the ramp is not
+       removable machinery.
 
        This ran late for a long time — pinned to the CLOSING of the mark
        (0.86-0.965 above) so the colour and the form arrived together. It no
@@ -854,11 +809,13 @@
        through — a resolve that lands on a tone has not resolved. */
     /* THE FILM IS TONED, NOT MONOCHROME.
        ------------------------------------------------------------------------
-       Sampled off photographs of the thing running: the ground is not black,
-       it is a deep indigo (#111228 measured, consistently across six frames),
-       and the marks are not white, they are a warm cream (#F5E1BA at the
-       arch's crown). Cool shadow, warm highlight — which is why it reads as a
-       surface catching light from a warm bulb rather than as a diagram.
+       Sampled off photographs of the thing running: the marks are not white,
+       they are a warm cream (#F5E1BA at the arch's crown). The ground was a
+       deep indigo (#111228 measured, consistently across six frames) when
+       those photographs were taken and is pitch black now — see the palette
+       note in index.html — so the warmth is carried entirely by the MARK, and
+       it still reads as a surface catching light from a warm bulb rather than
+       as a diagram.
 
        And the mark's HUE ramps with its brightness, which is the part that
        makes it look lit rather than coloured. Measured along the arch: the
@@ -912,12 +869,6 @@
     float lo      = smoothstep(0.30, 0.52, vyr);
     float hi      = smoothstep(0.46, 0.72, vyr);
     vec3  warm    = mix(mix(uTint, amber, lo), uInk, hi);
-    /* uTone is the whole of variation 4: at 0 the mark is flat uInk with no
-       ramp, and the bloom and spill below are zero, so the frame is ink or
-       paper and nothing between — the 1-bit contract with no atmosphere at
-       all. It is a separate switch from uShadow because the two pale variants
-       want their toning kept and only the shadow dropped. */
-    warm          = mix(uInk, warm, uTone);
     vec3  ink     = mix(warm, uInk2, resolve);
 
     float lowBias = mix(1.0, 0.35, smoothstep(-halfH, halfH, uv.y));
@@ -926,35 +877,11 @@
        ground stays cold the falloff turns grey no matter how red the ink is.
        Warm ground is what lets the limbs stay orange as they fade out. */
     float bloom   = pow(clamp(lumG, 0.0, 1.0), 0.42) * lowBias;
-    /* THE PAPER'S HALF OF IT, AND ON PAPER IT IS KEYED TO THE FRAME RATHER
-       THAN TO THE FORM.
-       Keying the ground to lumG is what makes the dark variant read as a lit
-       OBJECT: the light is the form's own, so it has to come off the form —
-       brightest along the stroke's spine, falling away to either side. On
-       paper that same term reads as a glow radiating out of the line, which
-       is a tube, not a print, and it fought the mark's ramp: the ramp runs up
-       the FRAME while the haze ran out of the LINE, so the two disagreed
-       about where the light was and the eye believed the nearer of them.
-
-       A sheet carries the light of the room it is in, and that light has a
-       direction — up from the floor, unchanged wherever the form happens to
-       be standing. So on paper the haze is a straight vertical wash on the
-       same axis as the ramp above it, and the frame finally makes one claim
-       instead of two: a single source under the picture, with the ink and the
-       stock both taking their colour from it.
-
-       0.16 AND NOT 0.42, WHICH IS WHERE IT WAS FIRST SET. That figure was
-       chosen on the front page, whose veil is an ellipse anchored at the
-       bottom of the frame with saturate(0) in it — so the floor of the frame,
-       which is exactly where this wash is strongest, was having most of its
-       colour taken out again before anyone saw it. The about page's veil is a
-       95deg linear sweep instead, covering the copy column on the left and
-       fading out by 82% across, so the same wash came through raw on the right
-       and laid a cyan band along the bottom of every screen there. The glow
-       the pale variants are for is carried by the MARKS; this is the sheet's
-       share of it, and the sheet's share is small. */
-    float wash    = pow(1.0 - vy, 1.55);
-    float haze    = mix(bloom * 0.55, wash * 0.16, uPrint) * (1.0 - resolve) * uTone;
+    /* Keyed to lumG — the form's own light — which is what makes the ground
+       read as a lit OBJECT rather than as a tinted sheet: brightest along the
+       stroke's spine, falling away to either side. It drains on the resolve
+       clock with everything else. */
+    float haze    = bloom * 0.55 * (1.0 - resolve);
     vec3  gnd     = mix(uPaper, uTint, haze);
 
     /* SPILL BETWEEN CELLS, which the blur above cannot produce on its own.
@@ -972,11 +899,8 @@
        they are orange. A tight exponent keeps it welded to the form — at
        the 0.42 the wide haze uses, a nearly-empty cell would still pick up
        a few percent and the dark would stop being dark. */
-    /* On paper this is the last thing that still hugs the form, so it is the
-       last thing that can read as a glow around the line: it stays only as
-       far as dot gain goes, a few percent of the stock taking ink. */
-    float spill   = pow(clamp(lumG, 0.0, 1.0), 1.1) * (1.0 - resolve) * uTone;
-    gnd           = mix(gnd, ink, spill * mix(0.42, 0.06, uPrint));
+    float spill   = pow(clamp(lumG, 0.0, 1.0), 1.1) * (1.0 - resolve);
+    gnd           = mix(gnd, ink, spill * 0.42);
 
 
     fragColor = vec4(mix(gnd, ink, cover), 1.0);
@@ -1070,7 +994,7 @@
     const UNIFORMS = ['uRes', 'uT', 'uG', 'uCell', 'uGap', 'uGain', 'uMode',
                       'uSection', 'uTex', 'uLat', 'uFov', 'uMouse', 'uAct',
                       'uTime', 'uAmb', 'uInk', 'uInk2', 'uPaper', 'uTint',
-                      'uShadow', 'uTone', 'uResolve', 'uPrint', 'uCopy', 'uLift'];
+                      'uResolve', 'uCopy', 'uLift'];
     function locate(p) {
       const m = {};
       for (const n of UNIFORMS) m[n] = gl.getUniformLocation(p, n);
@@ -1209,9 +1133,6 @@
       gl.uniform3f(uu.uPaper, paper[0], paper[1], paper[2]);
       const tint = o.tint || paper;
       gl.uniform3f(uu.uTint, tint[0], tint[1], tint[2]);
-      gl.uniform1f(uu.uShadow, o.shadow != null ? o.shadow : 1);
-      gl.uniform1f(uu.uTone, o.tone != null ? o.tone : 1);
-      gl.uniform1f(uu.uPrint, o.print != null ? o.print : 0);
       const m = o.mouse || [0, 0];
       gl.uniform2f(uu.uMouse, m[0], m[1]);
       gl.uniform1f(uu.uAct, o.act != null ? o.act : 0);

--- a/src/ptl-field.js
+++ b/src/ptl-field.js
@@ -101,17 +101,12 @@
   vec2  encLum(float l){ float q = clamp(l, 0.0, 1.0) * 255.0;
                          return vec2(floor(q) / 255.0, fract(q)); }
   float decLum(vec2 e){ return e.r + e.g / 255.0; }
-  /* The breathe rides in the third channel. It is a property of a CELL, like
-     the luminance, so it is evaluated where cells are evaluated — otherwise
-     the shading pass recomputes two sines per neighbour per pixel, eighteen a
-     pixel, to arrive at numbers the lattice pass already knew.
-
-     Measured honestly, this bought nothing on the software path: 36.0ms either
-     way, inside the noise. It is here because it is what makes the invariant
+  /* The breathe rides in the third channel: it is a property of a CELL, so it
+     is evaluated where cells are evaluated. That is what makes the invariant
      true — the shading pass evaluates NOTHING positional, it only reads — and
-     because eighteen transcendentals a pixel is a bill a phone pays even when
-     SwiftShader does not. One byte is plenty: it spans 0.88 to 1.135 — the
-     breathe itself only reaches 0.898..1.102 — so a step is a thousandth of a
+     it spares eighteen transcendentals a pixel, a bill a phone pays even
+     though it measured 36.0ms either way here. One byte is plenty: 0.88..1.135
+     spans the 0.898..1.102 the breathe reaches, so a step is a thousandth of a
      mark. */
   float encBrt(float b){ return clamp((b - 0.88) / 0.255, 0.0, 1.0); }
   float decBrt(float e){ return 0.88 + e * 0.255; }
@@ -161,6 +156,10 @@
      mark's lower edge is. */
   float baseOf(){
     return max(uRes.y, uRes.x / 1.78);
+  }
+  /* Half the frame's height in that same normalised space. */
+  float halfHOf(){
+    return 0.5 * uRes.y / baseOf();
   }
 
   float form(vec2 uv, float g){
@@ -385,19 +384,28 @@
     return smoothstep(30.0, 74.0, t) * (1.0 - smoothstep(150.0, 260.0, t));
   }
 
-  /* One mark's shadow, sampled at a point given RELATIVE to that mark's
-     centre in cell units. The distance from a point to a box is
-     length(max(|p| - half, 0)) — zero inside, Euclidean outside, so the
-     falloff is round at the corners even though the mark is square. */
+  /* ONE MARK'S SHADOW, and the only place the metric is argued. p is relative
+     to that mark's centre, in cell units.
+
+     Not Chebyshev. d — the metric whose circles ARE squares — gave every mark
+     a square halo with four sharp corners, and where those corners met across
+     a cell the field broke into hard rectangular patches, worse the more blur.
+     The distance from a point to a BOX, length(max(|p| - e, 0)), is Euclidean
+     outside and therefore round at the corners: a blurred shadow is round no
+     matter what shape cast it. Same cost, artefact gone rather than hidden.
+
+     But a wide blur does not PRESERVE a square either, it loses it, so the
+     metric follows the blur — hug the box while it is tight, go radial as it
+     grows past the mark.
+
+     ZERO SPREAD, ALL BLUR, AND THE BLUR SCALES WITH THE MARK: sg is
+     proportional with no constant term. Spread grows the shape before blurring
+     it, which is a plateau — the shadow would leave the edge already at full
+     strength. A floor would be spread wearing blur's name: it would hand a
+     one-pixel mark a fixed halo and the falloff, which is nothing but small
+     marks, would haze over. Scaled, a minuscule dot casts a minuscule shadow
+     and the dark stays dark. */
   float castShadow(vec2 p, float e, float sg){
-    /* A WIDE BLUR OF A SQUARE IS ROUND. Measuring from the BOX — the distance
-       length(max(|p| - e, 0)) — keeps the glow's contours square at every
-       radius: rounded rectangles whose corner radius is the distance itself,
-       which against a large mark is a square with the corners barely eased.
-       That is the squareness left after the ground was fixed. Convolving a
-       square with a kernel much wider than it does not preserve its shape, it
-       loses it, so the metric has to follow the blur: hug the box while the
-       blur is tight, and go radial as it grows past the mark. */
     float dBox = length(max(abs(p) - e, vec2(0.0)));
     float dRad = max(length(p) - e, 0.0);
     float rnd  = clamp(sg / max(e, 1e-4), 0.0, 0.55);
@@ -466,8 +474,7 @@
      the whole frame — marks, shadows, ground — is built from this lattice of
      samples and nothing else. */
   float formAt(vec2 id){
-    float base  = baseOf();
-    float halfH = 0.5 * uRes.y / base;
+    float halfH = halfHOf();
     vec2  uvc   = cellUv(id);
     float l = uMode == 0 ? form(uvc, uG)
             : uMode == 1 ? arch(uvc, halfH, uT)
@@ -497,9 +504,12 @@
     return texelFetch(uLat, t, 0).rgb;
   }
 
-  /* The breathe at one cell — evaluated in the lattice pass, alongside the
-     luminance, because it belongs to the same cell and runs on the same
-     clock. */
+  /* The breathe at one cell. It reaches the mark's SIZE and not the luminance
+     behind it: the form's bright core is saturated, so modulating lum there is
+     swallowed by the clamp and only the falloff would move — size is the one
+     channel a saturated cell still has room in. Two sines at unrelated rates,
+     which is what makes it read as breathing rather than as a loop, and it
+     dies on the closing track's window: the last frame is meant to be still. */
   float breatheAt(vec2 id){
     vec2  uvc  = cellUv(id);
     float wave = sin(uTime * 0.55 + uvc.x * 2.3 + uvc.y * 1.7)
@@ -514,14 +524,11 @@
   }
 
   void main(){
-    vec2 cellId = floor(gl_FragCoord.xy / uCell);
-    vec2 centre = (cellId + 0.5) * uCell;
-    /* Normalise on the long side. Dividing by height widens the horizontal
-       field on a letterboxed canvas instead of cropping it, which shrank the
-       subject to a stamp in the middle of a very wide empty frame. */
-    float base = baseOf();
-    vec2 uv = (centre - 0.5 * uRes) / base;
-    float halfH = 0.5 * uRes.y / base;
+    /* One divide, three readers: the cell id, the bilinear phase and gs. */
+    vec2 q = gl_FragCoord.xy / uCell;
+    vec2 cellId = floor(q);
+    vec2 uv = cellUv(cellId);
+    float halfH = halfHOf();
 
     /* THE GROUND IS THE SAME PICTURE THE MARKS ARE, AT THE SAME RESOLUTION.
        ------------------------------------------------------------------------
@@ -561,7 +568,7 @@
       }
     }
 
-    vec2  qc   = gl_FragCoord.xy / uCell - 0.5;  // cell CENTRES at the integers
+    vec2  qc   = q - 0.5;                        // cell CENTRES at the integers
     vec2  qlo  = floor(qc);                      // the four that surround us
     vec2  qf   = qc - qlo;
     ivec2 qi   = ivec2(qlo - cellId) + 1;        // 0 or 1 per axis, into L
@@ -575,46 +582,9 @@
     /* Signed cell coordinate, -1 to 1, zero at the mark's centre. The abs is
        what the mark itself needs; the SIGN is what tells a shadow which of its
        neighbours it is nearest to. */
-    vec2 gs = (fract(gl_FragCoord.xy / uCell) - 0.5) * 2.0;
+    vec2 gs = (fract(q) - 0.5) * 2.0;
     vec2 f  = abs(gs);
 
-    /* THE FIELD BREATHES.
-       --------------------------------------------------------------------
-       Applied to the mark's SIZE and not to the luminance behind it, which
-       matters: the bright core of the form is saturated, so modulating lum
-       there is swallowed by the clamp and only the falloff would move. Size
-       is the one channel every cell still has room in — a saturated cell can
-       always get smaller — so the whole field moves, core included, which is
-       what makes it read as a printed screen with a pulse rather than as a
-       soft edge wobbling.
-
-       Two sines at unrelated rates and unrelated directions. One alone is a
-       metronome sweeping the screen; summed, they never repeat inside any
-       time a reader will spend here, and the beat between them is what makes
-       it read as breathing rather than as a loop.
-
-       It dies as the form closes, on exactly the closing track's window: the
-       last frame of the page is meant to be still, and a mark that is still
-       pulsing under the closing claim is a film that has not ended.
-
-       The arithmetic lives in markOf, because it belongs to a CELL and the
-       shadow needs it for cells that are not this fragment's own. */
-
-    /* SOFT EDGES, deliberately. A hard step() gives a mark with a razor
-       border, which at this cell size reads as a printed screen — correct,
-       but inert. Feathering the edge by a fraction of a cell makes the marks
-       catch light the way an emulsion or a CRT phosphor does: the small ones
-       in the falloff dissolve into the ground instead of switching off, and
-       the field shimmers as the ambient breathe moves the boundary through
-       the feather rather than snapping it a whole pixel.
-
-       No fwidth() here: d is built from a fract(), whose derivative is
-       discontinuous at every cell boundary, so the analytic footprint is
-       garbage on exactly the pixels the edge runs through.
-
-       This is the one place the 1-bit contract is knowingly relaxed. It is
-       relaxed at the EDGE of a mark and nowhere else — the interior is still
-       exactly ink, the ground is still exactly paper. */
     /* The mark stays a TRUE square, sharp corners and all. Easing them into
        a squircle was a misread: the squareness that needed fixing was the
        GLOW's, and rounding the mark as well ate its corners until every mark
@@ -622,53 +592,6 @@
        square; only the light around them is not. */
     float d = max(f.x, f.y);
     float e = markOf(C[4]);
-    /* A DROP SHADOW, WHICH IS AN OUTSIDE-ONLY THING.
-       ------------------------------------------------------------------------
-       The mark stays a flat, hard square. Blurring the mark ITSELF looks
-       right in the abstract and is wrong the moment you see it: d is the
-       Chebyshev distance from the cell's centre, so a gradient in d is a
-       gradient in concentric SQUARES, and every mark comes out a little
-       pyramid with a lit apex and four shaded faces. The field turned to
-       studded leather. A shadow never touches the inside of the thing that
-       casts it; that is the whole difference between a shadow and a blur.
-
-       So: coverage is the square OR its shadow, whichever is greater. Inside,
-       the square is 1 and wins outright, which is what keeps the interior
-       flat and the 1-bit contract intact. Outside, the square is 0 and the
-       shadow decays from just under full opacity — exponential, because
-       "less spread, more blur" is exactly the difference between a profile
-       with a plateau and one that starts falling the instant it leaves the
-       edge. max() is also why a shadow can never lie on top of a neighbouring
-       mark: any cell holding a mark reads 1 there regardless.
-
-       ZERO SPREAD, ALL BLUR, AND THE BLUR SCALES WITH THE DOT. Spread grows
-       the shape before blurring it, which is a wider PLATEAU — the shadow
-       leaves the edge already at full strength and only then begins to fall.
-       There is none here: the exponential starts decaying the instant it
-       clears the mark. That is the whole reason the radius can be as large
-       as it is without the picture going to fog, and it is why sg is
-       PROPORTIONAL with no constant term. A floor would be spread wearing
-       blur's name — it would hand a one-pixel mark a fixed halo, and the
-       falloff, which is nothing but small marks, would haze over. Scaled,
-       a miniscule dot casts a miniscule shadow and the dark stays dark.
-
-       0.60, not 1.0, because a step function blurred by a symmetric kernel
-       is at HALF strength on the edge itself, not full — a shadow that
-       begins at 1.0 is just a bigger square. Held under, the mark keeps a
-       defined border with its light outside it.
-
-       The gate only closes one hole: at e exactly 0 the exponent is 0/0 at
-       the cell's centre pixel, which lights one pixel in every empty cell in
-       the frame — a speckle across the whole dark field. Everywhere else it
-       is already 1, so it costs nothing.
-
-       AND IT SHARPENS AS THE FILM ENDS. The blur is the atmosphere the
-       argument is told through; the last frame is the conclusion, and a
-       conclusion is not hazy. It begins at the fourth beat — where the
-       argument turns from picture to claim — and runs to the last frame, so
-       the sharpening is something the reader scrolls INTO rather than a
-       change that happens to them at the door, on the same clock the toning
-       drains on. Floored rather than zeroed: the shadow divides by sg. */
     /* ONE CLOCK, AND THE PAGE OWNS IT.
        ------------------------------------------------------------------------
        The shadow leaving, the feather tightening and the colour draining are
@@ -684,21 +607,25 @@
        knowing there is more than one. */
     float resolveU = clamp(uResolve, 0.0, 1.0);
 
-    /* THE FEATHER RESOLVES TOO, and it has to: once the shadow has gone this
-       is the ONLY softness left, so a 0.20e feather is still a 4.2px ramp on a
-       24px cell — which is exactly what reads as "still blurry" on the last
-       frame however sharp the shadow is.
-
-       Floored at half a device pixel rather than at a fraction of the mark, so
-       the last frame is a hard edge with one pixel of antialiasing at every
-       DPR instead of a hard edge that crawls on a 1x display. One gs unit is
-       half a cell, so one device pixel is 2/uCell of it. */
+    /* THE FEATHER, and the only place it is argued. A hard step() gives a
+       razor border — correct, and inert. Feathered by a fraction of a cell the
+       marks catch light the way an emulsion does: the small ones in the
+       falloff dissolve into the ground instead of switching off, and the field
+       shimmers as the breathe moves the boundary through the feather rather
+       than snapping a whole pixel. This is the one place the 1-bit contract is
+       knowingly relaxed, and it is relaxed at the EDGE only — the interior is
+       still exactly ink, the ground still exactly paper. No fwidth(): d comes
+       from a fract(), whose derivative is discontinuous at every cell wall, so
+       the analytic footprint is garbage on exactly the pixels the edge runs
+       through. It resolves with everything else, because once the shadow has
+       gone this is the only softness left and 0.20e is still a 4.2px ramp on a
+       24px cell. Floored at half a device pixel — one gs unit is half a cell,
+       so one device pixel is 2/uCell — so the last frame is a hard edge with
+       one pixel of AA at any DPR rather than one that crawls at 1x. */
     /* The reflection is NOT here, and it was: a depth term inside this feather
-       softened the mark itself toward the floor of the frame. It is a layer
-       over the canvas instead — .deep in the page — because softening the MARK
-       is the one trade this film refuses, while softening the FRAME leaves
-       every mark the shape it was drawn. Mirror of the .deep note in
-       index.html; keep the two in step. */
+       softened the mark itself. It is a layer over the canvas instead — .deep
+       in index.html — because softening the MARK is the one trade this film
+       refuses. Mirror of the .deep note there; keep the two in step. */
     float w     = max(e * mix(0.20, 0.02, resolveU), 1.0 / uCell);
     /* GATED AT ZERO. In an EMPTY cell e is 0, so w is 0 and this would be
        smoothstep(0, 0, d) — spec-undefined for edge0 >= edge1, and on the usual
@@ -712,59 +639,32 @@
     float mark  = (1.0 - smoothstep(e - w, e + w, d)) * smoothstep(0.0, 0.02, e);
 
 
-    /* ROUND, THOUGH THE MARK IS SQUARE. d is the Chebyshev distance — the
-       metric whose circles ARE squares — so driving the shadow off it gave
-       every mark a square halo with four sharp corners, and where those
-       corners met across a cell the field broke into hard rectangular
-       patches. Blocky, and the more blur the worse, because a bigger square
-       halo is a bigger square. The distance from a point to a BOX is
-       length(max(|p| - half, 0)), which is Euclidean outside and therefore
-       round at the corners — a blurred shadow is round no matter what shape
-       cast it. Same cost, and the artefact is gone rather than hidden. */
-    /* 0.80e — a fade length, not a reach. The falloff is exponential, so the
-       scale is where the shadow drops to 37%; it stays faintly visible to
-       roughly three times that. At the largest mark (e = 0.88 on a 12px cell,
-       where one unit of gs is half a cell = 6px) that is 4.2px of fade and
-       about 12px of visible glow — a reach of two cells, which is why it has
-       to be able to leave the cell it was cast in. Worth stating because it is
-       NOT Figma's number: Figma blurs with a gaussian, and the same-looking
-       softness carries a different figure there. */
+    /* A SHADOW BELONGS TO ITS MARK, NOT TO ITS CELL — and it is an
+       OUTSIDE-ONLY thing. Three rejected designs are why this loop is shaped
+       as it is, and all three came back looking plausible:
 
-    /* A SHADOW BELONGS TO ITS MARK, NOT TO ITS CELL.
-       ------------------------------------------------------------------------
-       This is the blockiness, and it took three wrong diagnoses to find.
+         · Blur the MARK. d is Chebyshev, so a gradient in it is a gradient in
+           concentric squares: every mark a little pyramid, the field studded
+           leather. A shadow never touches the inside of what casts it.
+         · Own cell only. gs wraps at the wall, so an empty cell beside a full
+           one got nothing while the fragment one pixel across got the whole
+           0.84 halo — an 84% coverage step along every wall, i.e. tiles.
+         · The nine neighbours sharing ONE e. Recorded as a proven no-op, and
+           it was: at equal mark size the fragment is nearest its own mark by
+           construction, so the max is always itself. A neighbour's shadow is
+           only ever about the neighbour being a DIFFERENT SIZE — markOf's job.
 
-       gs wraps at the cell wall, so a shadow computed from gs alone can only
-       ever be its OWN cell's — which means a fragment sitting in an empty cell
-       beside a full one gets nothing, while the fragment one pixel away on the
-       other side of the wall gets the full 0.84 of that mark's halo. That is a
-       hard step of 84% coverage running along a straight line, and a lattice of
-       straight lines is exactly what the picture looked like: tiles, at every
-       boundary where the form's brightness changed. Measured on the fourth
-       beat, the mean luminance step at the wall phase was ten times the step
-       anywhere else in the cell.
+       max, NOT sum. Summing nine inverts the lattice at this radius: four
+       marks are near a corner and one near a centre, so corners come out
+       brighter than marks (0.757 against 0.750) — a bright cross at every
+       corner, a dark ring around every mark. A union of shadows is a max,
+       which is also what keeps a shadow off a neighbouring mark.
 
-       An earlier attempt at the nine neighbours was recorded here as a proven
-       no-op, and it was — but only because it shared ONE e across all nine.
-       With the same mark size everywhere the fragment is nearest its own mark
-       by construction, so the max is always itself and the loop cannot do
-       anything. The whole content of a neighbour's shadow is that the
-       neighbour is a DIFFERENT SIZE, which is what markOf now supplies.
-
-       max, not sum. Summing nine was tried and inverts the lattice at this
-       radius — four marks are near a corner and one is near a centre, so the
-       corners come out brighter than the marks (0.757 against 0.750): a bright
-       cross at every corner, a dark ring around every mark. A union of shadows
-       is a max, which is also what keeps a shadow off a neighbouring mark:
-       cover takes the square first.
-
-       Continuity is the point, so it is worth stating why this is continuous.
-       Crossing the wall between cells A and B, the fragment's 3x3 changes by
-       exactly two columns — the one at distance three that leaves, and the one
-       at distance three that arrives. Three cell-units out the exponential is
-       at 5% for the largest mark on the page and immeasurable for any smaller
-       one, and it is the max of nine, so a term that small is buried by its
-       neighbours. The 84% step is gone and nothing takes its place. */
+       3x3 because 0.80e is a fade LENGTH, not a reach: at the largest mark
+       (e = 0.88, 12px cell, one gs unit = 6px) that is 4.2px of fade and about
+       12px of visible glow, two cells. And it stays continuous across a wall —
+       the 3x3 changes by two columns at distance three, where the exponential
+       is at 5% for the largest mark on the page and buried by the max anyway. */
     float shade = 0.0;
     for (int j = -1; j <= 1; j++){
       for (int i = -1; i <= 1; i++){
@@ -772,21 +672,29 @@
         /* One cell is TWO units of gs, so the neighbour's centre sits at
            2*off and the point handed to castShadow is gs measured from it. */
         float en  = markOf(C[(j + 1) * 3 + (i + 1)]);
+        /* sg tightens on the resolve clock — the blur is the atmosphere the
+           argument is told through, and the last frame is the conclusion.
+           Floored rather than zeroed because castShadow divides by it. */
         float sgn = mix(0.80 * en, 0.06 * en, resolveU) + 1e-4;
+        /* The gate closes one hole: at en exactly 0 the exponent is 0/0 at the
+           cell's centre pixel, lighting one pixel in every empty cell. */
         shade = max(shade, castShadow(gs - 2.0 * off, en, sgn)
                            * smoothstep(0.0, 0.02, en));
       }
     }
-    /* AND IT LEAVES ENTIRELY. Tightening sg alone takes the shadow to
-       0.06e, which is small but still 90% opaque against the mark's own
-       edge — a dark seam a pixel or two wide around every square, which is a
-       shadow, and the last frame is meant to have none. Multiplying it out
-       makes the end state arithmetically shadowless rather than nearly so,
-       and because sg tightens on the same clock it sharpens as it fades
-       rather than dissolving in place. (1.0 - resolveU) is the resolve clock,
-       not a switch: without it the last frame keeps its shadow. */
+    /* HELD UNDER FULL, AND THEN IT LEAVES ENTIRELY. 0.90 and not 1.0 because a
+       step blurred by a symmetric kernel is at HALF strength on the edge
+       itself: a shadow beginning at 1.0 is just a bigger square, and the mark
+       has to keep a defined border with its light outside it. (1.0 - resolveU)
+       is the resolve clock, not a switch — tightening sg alone leaves 0.06e,
+       still ~90% opaque against the mark's own edge, a dark seam a pixel or two
+       wide around every square. Multiplied out, the end state is
+       arithmetically shadowless, and it sharpens as it fades. */
     shade *= 0.90 * (1.0 - resolveU);
 
+    /* The square OR its shadow, whichever is greater. Inside, the square is 1
+       and wins outright, which is what keeps the interior flat and the 1-bit
+       contract intact; outside, the square is 0 and the shadow decays. */
     float cover = max(mark, shade);
 
     /* One bit per cell everywhere except the feathered edge above. Which two
@@ -807,34 +715,6 @@
        last section is meant to be a still white frame rather than a frame
        still cooling. uInk2 is therefore WHITE, not the cream the ramp passes
        through — a resolve that lands on a tone has not resolved. */
-    /* THE FILM IS TONED, NOT MONOCHROME.
-       ------------------------------------------------------------------------
-       Sampled off photographs of the thing running: the marks are not white,
-       they are a warm cream (#F5E1BA at the arch's crown). The ground was a
-       deep indigo (#111228 measured, consistently across six frames) when
-       those photographs were taken and is pitch black now — see the palette
-       note in index.html — so the warmth is carried entirely by the MARK, and
-       it still reads as a surface catching light from a warm bulb rather than
-       as a diagram.
-
-       And the mark's HUE ramps with its brightness, which is the part that
-       makes it look lit rather than coloured. Measured along the arch: the
-       crown is pale cream #F5E1BA, the mid limb a deeper amber #E4C198. That
-       is a black-body ramp — a filament is orange when it is dim and goes
-       pale as it heats — so the same ramp is what a real light does, and it
-       is what a flat mark colour cannot fake. uTint is the dim end.
-
-       The ground carries a small amount of the same warm at the same time, so
-       the light appears to spill off the form instead of stopping at its
-       edge, and it is WEIGHTED LOW: gl_FragCoord's origin is bottom-left, so
-       uv.y runs positive upward and the ramp below is full at the floor and
-       0.35 at the ceiling.
-
-       All of it drains on the closing window. As the form collapses the ramp
-       flattens to uInk2 and the ground returns to flat paper, so the last
-       frame is the palette's own two values with nothing added — the room
-       lights going down as the object arrives. */
-    float resolve = resolveU;
     /* KEYED TO THE FRAME, NOT TO THE FORM.
        Ramping on lum made the warmth radiate out of the arc's own centre —
        it travelled with the object, so every part of the form at the same
@@ -856,20 +736,27 @@
 
        Derived from the two ends rather than carried as a third uniform -- the
        page should not have to name a colour it cannot see. */
-    /* PEAK RED SITS AT A QUARTER HEIGHT, NOT AT THE FLOOR.
-       Running the reddest colour all the way down to vy = 0 put it exactly
-       where the arch's marks are smallest, so it never survived to the
-       screen: at partial coverage the mix runs ink toward GROUND, and orange
-       diluted by indigo is a neutral grey. Measured down the limb it came out
-       #4F413E with B/R 0.785 — desaturated, which is the "more white" that
-       band reads as. Held flat below a quarter height, the red lands while
-       the marks are still full strength, and stays red as they thin. */
+    /* THE FILM IS TONED, NOT MONOCHROME. Sampled off photographs of the thing
+       running, the marks are a warm cream (#F5E1BA at the arch's crown,
+       #E4C198 through the mid limb) — the ground is pitch black, so the warmth
+       is carried entirely by the MARK. The hue ramps with brightness, which is
+       what makes it read as lit rather than coloured: a black-body ramp, dim
+       and orange at uTint, pale as it heats, which a flat mark colour cannot
+       fake. The ground below carries a little of the same warm, weighted low,
+       so the light spills off the form instead of stopping at its edge. All of
+       it drains on the resolve clock: the last frame is the palette's own two
+       values with nothing added.
+
+       PEAK RED SITS AT A QUARTER HEIGHT, which is smoothstep's own edge0 of
+       0.30 below — at vy = 0 the arch's marks are smallest, and at partial
+       coverage the mix runs ink toward GROUND, so the red came out #4F413E,
+       B/R 0.785, a neutral grey. Held off the floor it lands while the marks
+       are still full strength and stays red as they thin. */
     vec3  amber   = mix(uTint, uInk, 0.52);
-    float vyr     = vy;
-    float lo      = smoothstep(0.30, 0.52, vyr);
-    float hi      = smoothstep(0.46, 0.72, vyr);
+    float lo      = smoothstep(0.30, 0.52, vy);
+    float hi      = smoothstep(0.46, 0.72, vy);
     vec3  warm    = mix(mix(uTint, amber, lo), uInk, hi);
-    vec3  ink     = mix(warm, uInk2, resolve);
+    vec3  ink     = mix(warm, uInk2, resolveU);
 
     float lowBias = mix(1.0, 0.35, smoothstep(-halfH, halfH, uv.y));
     /* And the ground under the form carries the same warm, weighted low. This
@@ -881,7 +768,7 @@
        read as a lit OBJECT rather than as a tinted sheet: brightest along the
        stroke's spine, falling away to either side. It drains on the resolve
        clock with everything else. */
-    float haze    = bloom * 0.55 * (1.0 - resolve);
+    float haze    = bloom * 0.55 * (1.0 - resolveU);
     vec3  gnd     = mix(uPaper, uTint, haze);
 
     /* SPILL BETWEEN CELLS, which the blur above cannot produce on its own.
@@ -899,7 +786,7 @@
        they are orange. A tight exponent keeps it welded to the form — at
        the 0.42 the wide haze uses, a nearly-empty cell would still pick up
        a few percent and the dark would stop being dark. */
-    float spill   = pow(clamp(lumG, 0.0, 1.0), 1.1) * (1.0 - resolve);
+    float spill   = pow(clamp(lumG, 0.0, 1.0), 1.1) * (1.0 - resolveU);
     gnd           = mix(gnd, ink, spill * 0.42);
 
 
@@ -918,6 +805,13 @@
      broke, here, rather than leaving the compiler to describe the symptom. */
   if (CUT < 0) throw new Error('PTLField: FRAG has no "  void main(){" to cut at');
   const COMMON   = FRAG.slice(0, CUT);
+  /* DERIVED FROM THE DECLARATIONS, not kept by hand beside them. A uniform
+     added to the shader and to feed() but not to this list gets an undefined
+     location, which WebGL treats as null — the write vanishes with no error and
+     the picture is quietly wrong. A stray `uniform` inside a GLSL comment would
+     add a name that resolves to null too, which makes its setters no-ops: the
+     benign direction of the same failure. */
+  const UNIFORMS = [...COMMON.matchAll(/uniform\s+\w+\s+(\w+)/g)].map(m => m[1]);
   const FRAG_LAT = COMMON + `void main(){
     /* One cell of border all round, so texel (0,0) is cell (-1,-1). */
     vec2 id = floor(gl_FragCoord.xy) - 1.0;
@@ -991,10 +885,6 @@
       return p;
     }
 
-    const UNIFORMS = ['uRes', 'uT', 'uG', 'uCell', 'uGap', 'uGain', 'uMode',
-                      'uSection', 'uTex', 'uLat', 'uFov', 'uMouse', 'uAct',
-                      'uTime', 'uAmb', 'uInk', 'uInk2', 'uPaper', 'uTint',
-                      'uResolve', 'uCopy', 'uLift'];
     function locate(p) {
       const m = {};
       for (const n of UNIFORMS) m[n] = gl.getUniformLocation(p, n);
@@ -1101,8 +991,7 @@
       gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, pad);
     }
 
-    function size() {
-      const dpr = Math.min(root.devicePixelRatio || 1, 2);
+    function size(dpr) {
       const nw = Math.round(canvas.clientWidth * dpr);
       const nh = Math.round(canvas.clientHeight * dpr);
       if (nw === w && nh === h) return;
@@ -1113,14 +1002,14 @@
     /* Both programs read the same picture, so both take the same uniforms.
        Handed the program's OWN location map, because a uniform location belongs
        to a program and using one against the other silently writes nothing. */
-    function feed(p, uu, t, o, dpr, mode) {
+    function feed(p, uu, t, o, cell, mode) {
       gl.useProgram(p);
       gl.uniform1i(uu.uTex, 0);
       gl.uniform1i(uu.uLat, 1);
       gl.uniform2f(uu.uRes, w, h);
       gl.uniform1f(uu.uT, t);
       gl.uniform1f(uu.uG, o.g != null ? o.g : t);
-      gl.uniform1f(uu.uCell, (o.cell != null ? o.cell : 12) * dpr);
+      gl.uniform1f(uu.uCell, cell);
       gl.uniform1f(uu.uGap, o.gap != null ? o.gap : 0.12);
       gl.uniform1f(uu.uGain, o.gain != null ? o.gain : 1.0);
       gl.uniform1i(uu.uMode, mode);
@@ -1147,11 +1036,16 @@
     function draw(t, o) {
       if (lost || dead) return;
       o = o || {};
-      size();
+      /* ONE READING OF EACH. The cell size below sizes the lattice texture and
+         is also what feed() writes into uCell — if the two ever disagreed the
+         one-cell border invariant breaks and every fragment's 3x3 reads the
+         wrong texels, a whole-frame corruption out of two lines that look
+         independent. So it is computed here and handed to both. */
       const dpr = Math.min(root.devicePixelRatio || 1, 2);
+      const cell = (o.cell != null ? o.cell : 12) * dpr;
+      size(dpr);
       const mode = MODES[o.mode || opt.mode] || 0;
       if (mode === 2 && o.word) setWord(o.word);
-      const cell = (o.cell != null ? o.cell : 12) * dpr;
 
       /* One texel per cell, plus a cell of border either side, so a fragment
          in the outermost cell can still ask about a neighbour beyond the frame
@@ -1172,13 +1066,13 @@
       /* PASS ONE: the picture, once per cell. */
       gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
       gl.viewport(0, 0, lw, lh);
-      feed(latProg, ul, t, o, dpr, mode);
+      feed(latProg, ul, t, o, cell, mode);
       gl.drawArrays(gl.TRIANGLES, 0, 3);
 
       /* PASS TWO: the frame, which now only has to read it. */
       gl.bindFramebuffer(gl.FRAMEBUFFER, null);
       gl.viewport(0, 0, w, h);
-      feed(prog, u, t, o, dpr, mode);
+      feed(prog, u, t, o, cell, mode);
       gl.drawArrays(gl.TRIANGLES, 0, 3);
     }
 

--- a/src/ptl-field.js
+++ b/src/ptl-field.js
@@ -38,6 +38,14 @@
     ASPECT: 1.78,            // the long-side normalisation, uRes.x / 1.78
   };
 
+  /* THE KEEP-OUT BAND for copy on the floor of a landscape frame: (centre,
+     half-height, half-width, falloff). Published because it is two things at
+     once — the value ptl-page.js seats the copy against, which had its own copy
+     of these four numbers, and feed()'s default for uCopy. A caller that says
+     nothing about copy gets a landscape floor cleared, which is a real decision
+     and one about.html has been inheriting without ever asking for it. */
+  const FLOOR = [-0.40, 0.10, 0.40, 0.21];
+
   /* ---- THE FIELD'S VOCABULARY ----------------------------------------------
      draw() takes colours as normalised triples and is driven by curves the page
      computes, so turning a stylesheet token into something it accepts is part of
@@ -64,6 +72,19 @@
     const c = i => Math.round((A[i] + (B[i] - A[i]) * t) * 255);
     return 'rgb(' + c(0) + ',' + c(1) + ',' + c(2) + ')';
   };
+
+  /* ---- THE AMBIENT CLOCK ---------------------------------------------------
+     It reaches exactly one thing — uTime, and through it the size of the
+     halftone marks — so it is the FIELD's clock, not either page's, and it lives
+     here. Both pages had their own copy of the arithmetic below, identical down
+     to the constants, and both had separately discovered the same two bugs: the
+     returning-tab delta, and that a decay tuned at 60Hz bleeds off twice as fast
+     at 120Hz unless it is raised per SECOND. One copy, so there is one place to
+     find them. The rAF pump stays with each page: they stop for genuinely
+     different reasons, and that is not shared logic. */
+  const AMB_IDLE = 1.0;    // clock seconds per real second, untouched
+  const AMB_GAIN = 5.5;    // extra, at full scroll speed
+  const AMB_DECAY = 0.86;  // how fast the boost bleeds off, per 60th of a second
 
   const VERT = `#version 300 es
   void main(){
@@ -577,6 +598,34 @@
     fragColor = vec4(encLum(formAt(id)), encBrt(breatheAt(id)), 1.0);
   }`;
 
+  /* ---- THE DRAW OPTIONS, AND EVERY DEFAULT IN ONE PLACE --------------------
+     This was two dozen lines of `o.x != null ? o.x : …`, each default buried at
+     its own call site. The second column IS the contract, and it is worth being
+     able to read down it: uCopy's default is how about.html came to have a
+     landscape keep-out band cut out of its field without anything in that file
+     saying so.
+
+     [uniform, option key, default, setter]. A null scalar default means "the t
+     draw() was called with". A string vector default names an earlier row to
+     fall back to, so ink2 follows ink and tint follows paper — order matters. */
+  const SCALARS = [
+    ['uG',       'g',       null, ],
+    ['uGap',     'gap',     0.12, ],
+    ['uGain',    'gain',    1.0,  ],
+    ['uAct',     'act',     0,    ],
+    ['uAmb',     'amb',     0,    ],
+    ['uResolve', 'resolve', 0,    ],
+    ['uLift',    'lift',    1,    ],
+  ];
+  const VECTORS = [
+    ['uMouse', 'mouse', [0, 0],    'uniform2fv'],
+    ['uInk',   'ink',   [1, 1, 1], 'uniform3fv'],
+    ['uInk2',  'ink2',  'ink',     'uniform3fv'],
+    ['uPaper', 'paper', [0, 0, 0], 'uniform3fv'],
+    ['uTint',  'tint',  'paper',   'uniform3fv'],
+    ['uCopy',  'copy',  FLOOR,     'uniform4fv'],
+  ];
+
   function compile(gl, type, src) {
     const s = gl.createShader(type);
     gl.shaderSource(s, src); gl.compileShader(s);
@@ -609,6 +658,9 @@
        the program. Nothing can be drawn after that, so the page stops asking
        rather than calling draw() on every scroll frame forever. */
     let dead = false;
+    /* The ambient clock's whole state — see AMB_* above. lastY starts where the
+       reader already is, so a deep link does not count the scroll it did not do. */
+    let clock = 0, vel = 0, lastTs = 0, lastY = root.scrollY || 0;
 
     function link(frag) {
       const vs = compile(gl, gl.VERTEX_SHADER, VERT);
@@ -713,27 +765,43 @@
       gl.useProgram(p);
       gl.uniform1i(uu.uLat, 0);
       gl.uniform2f(uu.uRes, w, h);
-      gl.uniform1f(uu.uG, o.g != null ? o.g : t);
       gl.uniform1f(uu.uCell, cell);
-      gl.uniform1f(uu.uGap, o.gap != null ? o.gap : 0.12);
-      gl.uniform1f(uu.uGain, o.gain != null ? o.gain : 1.0);
-      const ink = o.ink || [1, 1, 1], paper = o.paper || [0, 0, 0];
-      const ink2 = o.ink2 || ink;
-      gl.uniform3f(uu.uInk, ink[0], ink[1], ink[2]);
-      gl.uniform3f(uu.uInk2, ink2[0], ink2[1], ink2[2]);
-      gl.uniform3f(uu.uPaper, paper[0], paper[1], paper[2]);
-      const tint = o.tint || paper;
-      gl.uniform3f(uu.uTint, tint[0], tint[1], tint[2]);
-      const m = o.mouse || [0, 0];
-      gl.uniform2f(uu.uMouse, m[0], m[1]);
-      gl.uniform1f(uu.uAct, o.act != null ? o.act : 0);
-      gl.uniform1f(uu.uTime, o.time != null ? o.time : 0);
-      gl.uniform1f(uu.uAmb, o.amb != null ? o.amb : 0);
-      gl.uniform1f(uu.uResolve, o.resolve != null ? o.resolve : 0);
-      const box = o.copy || [-0.40, 0.10, 0.40, 0.21];   // the floor, the default
-      gl.uniform4f(uu.uCopy, box[0], box[1], box[2], box[3]);
-      gl.uniform1f(uu.uLift, o.lift != null ? o.lift : 1);
+      /* uTime is not a draw option: the clock below is the field's own. */
+      gl.uniform1f(uu.uTime, clock);
+      for (const [n, k, dflt] of SCALARS)
+        gl.uniform1f(uu[n], o[k] != null ? o[k] : (dflt == null ? t : dflt));
+      const V = {};
+      for (const [n, k, dflt, set] of VECTORS)
+        gl[set](uu[n], V[k] = o[k] || (typeof dflt === 'string' ? V[dflt] : dflt));
     }
+
+    /* ONE FRAME OF THE AMBIENT CLOCK. The page owns the rAF pump — the two stop
+       for genuinely different reasons — and calls this once per frame with the
+       timestamp and whether ambient motion is allowed. Returns dt in seconds.
+
+       lastTs is always updated, even when the clock is held: the gap while it
+       was off is not a frame's worth of time and must not be spent as one. */
+    function frame(ts, live) {
+      const raw = lastTs ? (ts - lastTs) / 1000 : 0.016;
+      /* Past 0.5s is a returning tab, not a slow frame. Applied to every frame
+         instead, the clock ran at 0.72 s/s at 15fps. */
+      const dt = raw > 0.5 ? 0.016 : Math.min(raw, 0.25);
+      lastTs = ts;
+      if (live) {
+        vel *= Math.pow(AMB_DECAY, dt * 60);   // per second, not per frame
+        clock += dt * (AMB_IDLE + AMB_GAIN * Math.min(vel, 1.4));
+      }
+      return dt;
+    }
+    /* Scroll makes the clock run faster. DISTANCE, not events: a trackpad fires
+       far more scroll events per pixel than a wheel, so counting events would
+       make one gesture mean different things on different hardware. */
+    function scrolled() {
+      vel += Math.abs(root.scrollY - lastY) / Math.max(root.innerHeight, 1);
+      lastY = root.scrollY;
+    }
+    /* A returning tab: forget the timestamp so the absence is not one delta. */
+    function idle() { lastTs = 0; }
 
     function draw(t, o) {
       if (lost || dead) return;
@@ -774,8 +842,9 @@
     /* isLost is the RECOVERABLE half of isDead: draw() returns immediately for
        both, but the page needs them apart — dead is terminal, lost is where it
        stops asking UNTIL the restore event, its cue to start again. */
-    return { draw, gl, canvas, isDead: () => dead, isLost: () => lost };
+    return { draw, gl, canvas, frame, scrolled, idle,
+             isDead: () => dead, isLost: () => lost };
   }
 
-  root.PTLField = { mount, CLOSE, clamp, lerp, smooth, hex3, mixHex };
+  root.PTLField = { mount, CLOSE, FLOOR, clamp, lerp, smooth, hex3, mixHex };
 })(window);

--- a/src/ptl-field.js
+++ b/src/ptl-field.js
@@ -1,32 +1,20 @@
 /* ============================================================================
    PTL — procedural field renderer
    ----------------------------------------------------------------------------
-   Replaces the video chain. The reference set (Algolia, Pulse, the checkerboard
-   posters, the dot spheres) is not photographic: every one is a single coherent
-   form built from a regular grid of marks, falling off into black. You cannot
-   get that by crushing a photograph to 1-bit — crushing a photograph gives you
-   noise, which is what the video build shipped. You get it by drawing the grid.
+   THE THESIS: a halftone, not a dither — a rigid grid of marks whose SIZE
+   carries the image. The reference set is one coherent form on a regular grid
+   falling off into black, and crushing a photograph to 1-bit gives noise, not
+   that. Fixed-size on/off is a dot-matrix printer, and that crunch is most of
+   what reads cheap. Area proportional to luminance means sqrt() on the side;
+   every pixel is still pure black or pure white.
 
-   Whatever the subject, the output stage is the same and is the thing that
-   matters: a rigid grid of marks whose SIZE carries the image. An on/off dither
-   at one fixed size is a 1980s dot-matrix printer, and that crunch was most of
-   what read as cheap. Area proportional to luminance means sqrt() on the side.
-   Every pixel is still pure black or pure white.
+   Three treatments share that output stage: FORM, one abstract form in screen
+   space, no world and no camera; ARCH, raymarched concrete flying past; TYPE,
+   Cormorant rendered to a texture and halftoned on the same grid.
 
-   Three treatments share that stage:
-
-     FORM  a single abstract form per section, in screen space. No world, no
-           camera. This is what the references literally are.
-     ARCH  the storyboard's monumental concrete, raymarched, camera flying
-           forward. The machine sublime, at the cost of reading as stripes when
-           the grid is only ~130 marks across.
-     TYPE  the words themselves as the picture — Cormorant rendered to a
-           texture, warped, and halftoned on the same grid.
-
-   Drawing rather than filming also buys: exact art direction (a near mass is an
-   unlit silhouette because RANGE says so, not because a model agreed to it),
-   and zero scroll latency (a field is a pure function of scroll position, where
-   a video scrub measured 90ms median and spiked past 600ms).
+   Drawn rather than filmed, for exact art direction (a near mass is an unlit
+   silhouette because RANGE says so) and zero scroll latency — a video scrub
+   measured 90ms median, spiking past 600ms.
 
    USAGE
      const f = PTLField.mount(canvas, { mode: 'form' });
@@ -35,21 +23,12 @@
 (function (root) {
   'use strict';
 
-  /* WHERE THE MARK ENDS UP.
-     ------------------------------------------------------------------------
-     The page needs to know the closing mark's geometry in order to keep the
-     final line of type clear of it, and the shader is a string — it cannot
-     read a JS constant, and JS cannot read its literals. So the numbers are
-     named here and the two readers are kept adjacent: form()'s closing tracks
-     below, and PTLField.CLOSE, which ptl-page.js resolves into screen pixels.
-
-     They already came apart once. Retiming the close from 0.88→1.00 to
-     0.86→0.965 to buy a held end frame moved the mark out from under the
-     claim, and the claim's own arithmetic had to be chased separately. If you
-     retune a track below, retune the matching field here in the same edit.
-
-     R and CY are END values — the sums the radius and centre tracks arrive at
-     once every earlier track has run out — not any single track's argument. */
+  /* WHERE THE MARK ENDS UP. ptl-page.js keeps the last line of type clear of
+     the closing mark, and the shader is a string: it cannot read a JS constant,
+     nor JS its literals. So the numbers live between their two readers —
+     form()'s closing tracks below, and PTLField.CLOSE. They have come apart
+     before: retune a track, retune the field here in the same edit. R and CY
+     are END values, not any single track's argument. */
   const CLOSE = {
     FROM: 0.86, TO: 0.965,   // the closing track's window in global scroll
     R:    0.27,              // radius at 0.86, before the close
@@ -92,165 +71,116 @@
   uniform vec4      uCopy;      // the copy's box: (centre, half-height, half-width, falloff)
   uniform float     uLift;      // 1 the mark rides above centre, 0 it sits on it
 
-  /* A LUMINANCE IN A BYTE PAIR. The lattice pass writes to an RGBA8 target —
-     the one colour-renderable format WebGL2 guarantees without an extension —
-     and one byte per cell is not enough: the ground raises lum to the 0.42, so
-     a single 1/255 step at the bottom of the range opens to a tenth of the
-     bloom and the dark banded. Split across two channels this carries 16 bits,
-     which is more than the picture has. */
+  /* A LUMINANCE IN A BYTE PAIR. RGBA8 is the only colour-renderable format
+     WebGL2 guarantees, and one byte per cell is not enough: the ground raises
+     lum to the 0.42, so a single 1/255 step at the bottom of the range opens to
+     a tenth of the bloom and the dark banded. Two channels carry 16. */
   vec2  encLum(float l){ float q = clamp(l, 0.0, 1.0) * 255.0;
                          return vec2(floor(q) / 255.0, fract(q)); }
   float decLum(vec2 e){ return e.r + e.g / 255.0; }
-  /* The breathe rides in the third channel: it is a property of a CELL, so it
-     is evaluated where cells are evaluated. That is what makes the invariant
-     true — the shading pass evaluates NOTHING positional, it only reads — and
-     it spares eighteen transcendentals a pixel, a bill a phone pays even
-     though it measured 36.0ms either way here. One byte is plenty: 0.88..1.135
-     spans the 0.898..1.102 the breathe reaches, so a step is a thousandth of a
-     mark. */
+  /* The breathe rides in the third channel because it is a property of a CELL.
+     That keeps the shading pass free of anything positional — it only reads —
+     and saves eighteen transcendentals a pixel. 0.88..1.135 spans the
+     0.898..1.102 the breathe reaches. */
   float encBrt(float b){ return clamp((b - 0.88) / 0.255, 0.0, 1.0); }
   float decBrt(float e){ return 0.88 + e * 0.255; }
 
   float hash(vec2 p){ return fract(sin(dot(p, vec2(41.3, 289.1))) * 43758.5453); }
 
   /* ---- FORM ----------------------------------------------------------------
-     ONE circle, for the whole page.
+     ONE circle, for the whole page. Six section-selected branches meant five
+     hard cuts; don't join two things, have one thing the whole way. The opening
+     "arc" is this same circle at colossal radius, centre far below the frame,
+     so only its top edge is in shot.
 
-     The first version was six independent branches selected by section, which
-     meant five hard cuts — the arc simply vanished and a ring appeared. That is
-     the same defect as a bad seam in the video chain, and the fix is the same:
-     don't join two things, have one thing the whole way.
-
-     So there is a single circle, and every beat of the argument is a continuous
-     transformation of it. The opening arc is not an arc at all — it is this
-     circle at colossal radius with its centre far below the frame, so only its
-     top edge is in shot. Raising the centre and shrinking the radius turns that
-     arc into the ring without anything appearing or disappearing.
-
-       0.00-0.28  DECIDE  centre rises from below, radius collapses: the arc
-                          becomes a ring
+       0.00-0.28  DECIDE  centre rises, radius collapses: arc becomes ring
        0.28-0.50  WHEN    the ring holds and tightens
-       0.33-0.50  EARN    a lattice grows OUT of the ring, its void being the
-                          ring's own interior
+       0.33-0.50  EARN    a lattice grows OUT of the ring, its void the ring
        0.50-0.67  COMMIT  the lattice loses cells and goes out of register
-       0.67-0.86  PRICE   every cell returns and snaps back into exact register
+       0.67-0.86  PRICE   every cell returns and snaps back into register
        0.84-0.965 END     the lattice falls away, the ring closes to one mark
        0.965-1.00         held: the film is over and the frame is still
 
-     Everything below is a track on uG (global scroll), never on section index,
-     which is what makes it continuous by construction rather than by tuning.  */
+     Every track runs on uG (global scroll), never on section index: continuous
+     by construction rather than by tuning. */
   float track(float g, float a, float b, float v0, float v1){
     return mix(v0, v1, smoothstep(a, b, g));
   }
 
-  /* THE NORMALISATION, AND THE ONLY COPY OF IT.
-     Dividing by the height widens the horizontal field on a letterboxed canvas
-     instead of cropping it, which stops the subject shrinking to a stamp in
-     the middle of a very wide empty frame. On a portrait frame the same rule
-     scales the form to the HEIGHT, so the ring is wider than the phone and its
-     left and right run off the edges — deliberately. Capping it to the width
-     was tried and reverted: it fixes a silhouette nobody was looking at and
-     costs the whole film its scale, including the closing mark, which came out
-     42% smaller than it is meant to be. The number lives in CLOSE at the top of
-     this file, because ptl-page.js does this arithmetic too, to know where the
-     mark's lower edge is. */
+  /* THE NORMALISATION, AND THE ONLY COPY OF IT. Dividing by the height widens a
+     letterboxed canvas instead of cropping it, so the subject does not shrink
+     to a stamp. In portrait it scales to the HEIGHT and the ring runs off both
+     edges — deliberately: capping to the width was tried and reverted, fixing a
+     silhouette nobody was looking at at the cost of 42% of the closing mark's
+     size. Mirrored in CLOSE, which ptl-page.js reads. */
   float baseOf(){
     return max(uRes.y, uRes.x / 1.78);
   }
-  /* Half the frame's height in that same normalised space. */
   float halfHOf(){
     return 0.5 * uRes.y / baseOf();
   }
 
   float form(vec2 uv, float g){
-    /* The circle. Centre and radius are one continuous path from "colossal and
-       mostly off-frame" to "a single mark at the middle". */
-    /* The high arch. A colossal radius with the centre pushed far down flattens
-       the curve into a shallow lens; the arch reads as an arch when the apex is
-       high AND the legs fall away steeply to the side edges, which needs a
-       SMALLER radius and a centre nearer the frame. Solved for apex at +0.32
-       and the legs crossing the frame edge at -0.12. */
-    /* The mark leans toward the pointer — barely. At 0.042 it read as a thing
-       being dragged around; the movement was the effect instead of inflecting
-       it. A hundredth and a half of a uv unit is under twenty pixels across
-       the whole screen, which is felt rather than watched, and it leaves the
-       travelling light to carry the life. */
+    /* The mark leans toward the pointer — barely. 0.042 read as a thing being
+       dragged around; 0.015 uv is under twenty pixels across the screen, felt
+       rather than watched, leaving the light to carry the life. */
     vec2 lean = uMouse * 0.015 * uAct;
     uv -= lean;
 
-    /* The end values of these two tracks, and of bw below, are mirrored in
-       CLOSE at the top of this file — see the note there before retuning. */
-    /* uLift is the END of this track only — the opening's -0.80 is what puts
-       the reader inside a colossal circle and is not negotiable. The 0.02 it
-       settles at lifts the mark to leave room UNDER it for copy, which on a
-       phone is not where the copy is; there the page passes 0 and the mark
-       comes to rest on the frame's own centre, with the words in the middle
-       of it. */
+    /* Centre and radius are one continuous path from "colossal and mostly
+       off-frame" to "one mark at the middle"; solved for apex +0.32 with the
+       legs crossing the frame edge at -0.12, an arch reading as an arch only
+       when the legs fall steeply as well as the apex being high. These end
+       values, and bw's, are mirrored in CLOSE — read the note there before
+       retuning. The opening -0.80 puts the reader inside a colossal circle and
+       is not negotiable. uLift scales only the END: 0.02 leaves room UNDER the
+       mark for copy, which on a phone is not where the copy is — there the page
+       passes 0 and the words sit inside the mark. */
     float cy = track(g, 0.00, 0.30, -0.80, 0.02 * uLift);   // CLOSE.CY
     float r  = track(g, 0.00, 0.30,  1.12, 0.34)
              - track(g, 0.30, 0.50,  0.00, 0.07)      // WHEN: tightens
              + track(g, 0.52, 0.66,  0.00, 0.05)      // COMMIT: breathes out
              - track(g, 0.70, 0.86,  0.00, 0.05)      // PRICE: back into register
-             /* END: closes to a mark, and is DONE closing at 0.965 rather than
-                at 1.00. The film used to still be moving at the last pixel of
-                scroll, so its final frame existed only at the very bottom and
-                the closing statement had nothing steady to sit under. Landing
-                early buys a held end card — the last ~3% of the page is one
-                still frame: the mark, and the claim beneath it. */
+             /* END: done closing at 0.965, not 1.00. Still moving at the last
+                pixel of scroll, the final frame existed only at the very bottom
+                and the closing statement had nothing steady to sit under.
+                Landing early buys a held end card of ~3% of the page. */
              - track(g, 0.86, 0.965, 0.00, 0.24);   // CLOSE.FROM/TO/DR; the
                                                     // sum above it is CLOSE.R
     vec2  c  = vec2(0.0, cy);
     float len = length(uv - c);
 
-    /* Band width follows the same path: thick and soft while the circle is
-       colossal, tight once it is a ring. */
-    /* 0.13 is the original's value and it is load-bearing. Raising it to 0.23
-       to chase a higher apex was the wrong lever: the apex comes from the
-       centre and radius, the WEIGHT comes from here, and fattening the band
-       turned a drawn edge into a slab. Height and thickness are independent —
-       change the one you actually mean. */
+    /* Band width follows the same path: thick and soft while colossal, tight
+       once it is a ring. 0.13 is load-bearing — the apex comes from the centre
+       and the radius, the WEIGHT from here, and raising it to 0.23 to chase a
+       higher apex turned a drawn edge into a slab. */
     float bw = track(g, 0.00, 0.30, 0.13, 0.045);   // CLOSE.BW
 
     float ring = 1.0 - smoothstep(0.0, bw, abs(len - r));
 
     /* Only while the circle is colossal: dim the ends so the top edge reads as
-       one lit arc in the dark rather than as a band running off both sides. */
+       one lit arc in the dark rather than a band running off both sides. */
     float ends = 1.0 - smoothstep(0.30, 1.05, abs(uv.x));
     ring *= mix(0.45 + 0.75 * ends, 1.15, smoothstep(0.10, 0.30, g));
 
-    /* At the very end the ring is small enough that a hole in it reads as a
-       defect, so it fills — the last mark on the page is solid. */
+    /* At the end the ring is small enough that a hole reads as a defect, so it
+       fills — the last mark on the page is solid. */
     float closed = smoothstep(0.885, 0.965, g);
     ring = max(ring, (1.0 - smoothstep(r * 0.6, r * 1.25, len)) * closed);
 
-    /* THE MARK ANSWERS THE POINTER.
-       --------------------------------------------------------------------
-       Once it has closed, the mark is the only thing left on the page, and a
-       still disc is a full stop. Lighting it makes it an object instead: the
-       flat radial falloff is replaced by a hemisphere shaded from a direction
-       the reader controls, so the terminator sweeps across the halftone and
-       the marks on the dark side shrink while the lit side swells. Nothing
-       translates — the CELLS are fixed and only their coverage changes, which
-       is the same grammar as the rest of the film.
-
-       Cheap, because the normal is analytic: inside a disc of radius r, the
-       unit sphere's z is sqrt(1 - |p|^2). No raymarch, no geometry.
-
-       Applied to the WHOLE body and not to the fill alone. Lighting only the
-       fill left the ring — which still peaks at len = r, a couple of cells out
-       from the middle — at full strength beside a dimmed core, and the two
-       disagreed as a pinch of small cells at the centre of the disc. One
-       object, one light. */
+    /* THE MARK ANSWERS THE POINTER. Once closed it is the only thing left on
+       the page, and a still disc is a full stop; lighting makes it an object.
+       Nothing translates — the CELLS are fixed and only their coverage changes,
+       the grammar of the rest of the film. Cheap, because the normal is
+       analytic: inside a disc of radius r, z is sqrt(1 - |p|^2). Applied to the
+       WHOLE body, not the fill alone — lighting only the fill left the ring
+       (still peaking at len = r) at full strength beside a dimmed core, and the
+       two disagreed as a pinch of small cells at the disc's centre. */
     float lightAmt = uAct * closed;
     if (lightAmt > 0.001){
-      /* DISTANCE EASING — the mark is FULLER the closer you get.
-         The first version had this backwards. It ramped the shading up with
-         proximity, so approaching the mark made it darker and sparser and
-         backing away made it whole: the thing recoiled from attention. It
-         should do the opposite. Near, it comes up to full strength and takes
-         a clear light; far, it sinks toward a dim, flat, half-present state.
-         Two separate terms, because they are two different ideas — how much
-         of the mark is there (lvl), and how sculpted it is (dirA). */
+      /* DISTANCE EASING — the mark is FULLER the closer you get; backwards, it
+         recoiled from attention. Two terms because they are two ideas: how much
+         of the mark is there, and how sculpted it is. */
       float d    = length(uMouse - vec2(0.0, cy));
       float near = 1.0 - smoothstep(0.10, 0.92, d);
       float lvl  = mix(0.56, 1.00, near);   // how present the mark is
@@ -261,18 +191,15 @@
       vec3  n  = normalize(vec3(np, max(nz, 0.06)));
       vec3  L  = normalize(vec3(uMouse * 1.30, 0.74));
       float lam = max(dot(n, L), 0.0);
-      /* The hot spot is what sells it as a surface rather than a gradient: it
-         slides across the halftone a beat ahead of the terminator. */
+      /* The hot spot sells it as a surface rather than a gradient: it slides
+         across the halftone a beat ahead of the terminator. */
       float spec = pow(max(dot(reflect(-L, n), vec3(0.0, 0.0, 1.0)), 0.0), 20.0) * 0.30;
 
-      /* THE LIMB, READ DIRECTIONALLY.
-         An undirected rim brightens the whole edge, which reads as a vignette
-         and does not move. Splitting it by which way the edge faces gives two
-         things for one dot product: a lit lip on the near side, and an inner
-         shadow — a shaded band just inside the far edge — that travels around
-         the disc as the pointer moves. That travelling shadow is most of what
-         makes the mark read as a solid rather than a disc with a gradient on
-         it, because it is the only cue that says the surface curves AWAY. */
+      /* THE LIMB, READ DIRECTIONALLY. An undirected rim brightens the whole
+         edge: a vignette, and it does not move. Split by which way the edge
+         faces, one dot product buys a lit lip near side and an inner shadow
+         travelling round the far edge — the only cue saying the surface curves
+         AWAY, and most of what makes the mark read as solid. */
       float lm   = length(L.xy);
       vec2  ldir = lm > 1e-3 ? L.xy / lm : vec2(0.0);   // head-on: no side, no lip
       float side = dot(normalize(np + vec2(1e-5)), ldir);
@@ -280,30 +207,25 @@
       float lip   = limb * max( side, 0.0) * 0.14;
       float shade = limb * max(-side, 0.0) * 0.40;
 
-      /* The lighting PEAKS AT ONE. It may shade the mark; it may never
-         brighten it. This is the whole difference between a halftone and a
-         circle: the image is carried by mark SIZE, size is sqrt(luminance),
-         and luminance clamps at 1 — so a lighting term that peaks above 1
-         drives every cell in the lit region to full size and flattens the
-         size gradient into a plateau. An earlier version peaked at 1.34,
-         which saturated everything inside len = 0.04 and turned the mark
-         into a solid disc with a halftone fringe. Capped here, the field's
-         own radial falloff stays the structure and the light only tilts it. */
+      /* THE LIGHTING PEAKS AT ONE. It may shade the mark, never brighten it:
+         size is sqrt(luminance) and luminance clamps at 1, so a term peaking
+         above 1 drives every lit cell to full size and flattens the gradient
+         into a plateau — at 1.34, everything inside len = 0.04 saturated and
+         the mark became a solid disc with a halftone fringe. */
       float shape = 0.38 + 0.62 * lam * lam + spec + lip - shade;
       float lit   = clamp(mix(1.0, shape, dirA) * lvl, 0.0, 1.0);
       ring *= mix(1.0, lit, lightAmt);
     }
 
-    /* The lattice. Its grid is anchored to the circle's centre, so it grows out
-       of the ring rather than arriving over the top of it, and its inner edge
-       IS the ring — the void at the middle of section 3 is the circle. */
+    /* The lattice, anchored to the circle's centre so it grows out of the ring
+       rather than arriving over the top of it: its inner edge IS the ring. */
     float latAmt = track(g, 0.33, 0.46, 0.0, 1.0) * track(g, 0.84, 0.945, 1.0, 0.0);
     float lat = 0.0;
     if (latAmt > 0.001){
       vec2 gc  = (uv - c) * 13.0;
       vec2 cid = floor(gc);
-      /* Out of register, then back. Peaks inside COMMIT and is fully resolved
-         by the end of PRICE, which is the argument those two sections make. */
+      /* Out of register, then back: peaks inside COMMIT, fully resolved by the
+         end of PRICE, which is the argument those two sections make. */
       float jt = track(g, 0.50, 0.62, 0.0, 1.0) * track(g, 0.68, 0.85, 1.0, 0.0);
       float rm = track(g, 0.50, 0.64, 0.0, 0.55) * track(g, 0.70, 0.86, 1.0, 0.0);
       vec2 jitter = (vec2(hash(cid), hash(cid + 7.1)) - 0.5) * 1.5 * jt;
@@ -315,33 +237,21 @@
       lat = rule * keep * ann * latAmt;
     }
 
-    /* The form parts around the copy, in the COLUMN the copy occupies only —
-       the arch's legs live out at the frame edges where no type ever goes, and
-       clearing the whole lower band amputated them.
-
-       A backdrop blur was tried in place of this and reverted: defocusing the
-       field behind the type keeps more of the picture, but the picture it keeps
-       is a soft grey smear, and the thing that makes this page work is that
-       every mark is hard. Parting around the copy is better because the field
-       stays sharp everywhere it is visible. */
-    /* uCopy IS THE BOX THE WORDS OCCUPY, and the page measures it — this used
-       to be three constants that described the bottom of a landscape frame,
-       which is only where the copy is when the frame is landscape. On a phone
-       the copy sits in the middle, and a keep-out aimed at the floor cleared
-       the one part of the picture that had nothing in front of it while
-       leaving the marks that were directly under the headline. The tapers are
-       falloff is the box's own fourth number, 0.21 on the floor — which with
-       the 1.62 the sides take is the shipped 0.34 — so a wide frame, where the
-       page passes the floor box, draws exactly what it drew before. */
+    /* The form parts around the copy, in its COLUMN only — the arch's legs live
+       at the frame edges where no type goes, and clearing the whole lower band
+       amputated them. A backdrop blur was tried instead and reverted: it keeps
+       more of the picture, but as a soft grey smear, and what makes this page
+       work is that every mark is hard. uCopy is the box the words occupy,
+       MEASURED BY THE PAGE, because three constants describing a landscape
+       floor is not where the copy is on a phone. Its fourth number is the
+       falloff, 0.21 on the floor, which with the 1.62 the sides take is the
+       shipped 0.34: a wide frame draws what it drew before. */
     float column = 1.0 - smoothstep(uCopy.z, uCopy.z + uCopy.w * 1.62, abs(uv.x));
-    /* uv is normalised by 'base', which is the LONG side — in landscape that is
-       the width, so uv.y stops meaning "share of the visible frame" and the
-       keep-out drifts off the bottom of a short viewport. On an 844x390 phone
-       the cleared band began at 238px while the copy started at 152px, and the
-       headline was set straight over the brightest marks in the picture. sy
-       converts back to a fraction of the actual height, so the band is always
-       the same share of what the reader can see. On a viewport at or taller
-       than 16:9 this is exactly uv.y and nothing changes. */
+    /* uv is normalised on the LONG side, so in landscape uv.y stops meaning
+       "share of the visible frame" and the keep-out drifts off a short
+       viewport: on an 844x390 phone the band began at 238px with the copy at
+       152px. sy converts back to a fraction of the actual height; at or taller
+       than 16:9 it is exactly uv.y. */
     float base   = baseOf();
     float sy     = uv.y * base / uRes.y;
     float band   = 1.0 - smoothstep(uCopy.y, uCopy.y + uCopy.w, abs(sy - uCopy.x));
@@ -352,7 +262,7 @@
 
   /* ---- ARCH ----------------------------------------------------------------
      The storyboard's world, raymarched. Kept whole so the three treatments are
-     a fair comparison rather than one of them being a sketch.                 */
+     a fair comparison rather than one of them a sketch.                       */
   float sdBox(vec3 p, vec3 b){
     vec3 q = abs(p) - b;
     return length(max(q, 0.0)) + min(max(q.x, max(q.y, q.z)), 0.0);
@@ -360,10 +270,9 @@
 
   float map(vec3 p){
     float d = 1e9;
-    /* Floating, never standing. The brief says unbounded void with no ground,
-       and honouring it pays compositionally: the masses have visible bottom
-       edges which converge toward the horizon, leaving a black wedge along the
-       bottom of the frame for type. */
+    /* Floating, never standing — unbounded void, no ground. It pays
+       compositionally: the masses have visible bottom edges converging toward
+       the horizon, leaving a black wedge along the frame's floor for type. */
     vec3 q = p;
     q.z = mod(q.z + 13.0, 26.0) - 13.0;
     float sway = float(uSection) * 1.7;
@@ -377,9 +286,8 @@
     return d;
   }
 
-  /* The clause the video model would not obey, written as arithmetic: nothing
-     is lit closer than NEAR, so a mass arriving at the lens goes to silhouette
-     rather than to the lit grey slab the model insisted on. */
+  /* Nothing is lit closer than NEAR, so a mass arriving at the lens goes to
+     silhouette rather than to a lit grey slab. */
   float range(float t){
     return smoothstep(30.0, 74.0, t) * (1.0 - smoothstep(150.0, 260.0, t));
   }
@@ -387,24 +295,17 @@
   /* ONE MARK'S SHADOW, and the only place the metric is argued. p is relative
      to that mark's centre, in cell units.
 
-     Not Chebyshev. d — the metric whose circles ARE squares — gave every mark
-     a square halo with four sharp corners, and where those corners met across
-     a cell the field broke into hard rectangular patches, worse the more blur.
-     The distance from a point to a BOX, length(max(|p| - e, 0)), is Euclidean
-     outside and therefore round at the corners: a blurred shadow is round no
-     matter what shape cast it. Same cost, artefact gone rather than hidden.
+     Not Chebyshev: the metric whose circles ARE squares gave every mark a
+     square halo whose corners met across a cell in hard rectangular patches,
+     worse the more blur. Distance to a BOX is Euclidean outside and therefore
+     round at the corners, at the same cost. A wide blur loses a square anyway,
+     so the metric follows the blur — hug the box while it is tight, go radial
+     as it grows past.
 
-     But a wide blur does not PRESERVE a square either, it loses it, so the
-     metric follows the blur — hug the box while it is tight, go radial as it
-     grows past the mark.
-
-     ZERO SPREAD, ALL BLUR, AND THE BLUR SCALES WITH THE MARK: sg is
-     proportional with no constant term. Spread grows the shape before blurring
-     it, which is a plateau — the shadow would leave the edge already at full
-     strength. A floor would be spread wearing blur's name: it would hand a
-     one-pixel mark a fixed halo and the falloff, which is nothing but small
-     marks, would haze over. Scaled, a minuscule dot casts a minuscule shadow
-     and the dark stays dark. */
+     ZERO SPREAD, ALL BLUR, SCALED WITH THE MARK: sg is proportional with no
+     constant term. Spread grows the shape before blurring, which is a plateau,
+     and a floor would hand a one-pixel mark a fixed halo and haze over the
+     falloff, which is nothing but small marks. */
   float castShadow(vec2 p, float e, float sg){
     float dBox = length(max(abs(p) - e, vec2(0.0)));
     float dRad = max(length(p) - e, 0.0);
@@ -440,11 +341,9 @@
   }
 
   /* ---- TYPE ----------------------------------------------------------------
-     The word as the picture. The texture is Cormorant drawn white on black at
-     high resolution; the warp is a displacement that eases out as the section
-     resolves, so the word arrives out of distortion rather than fading in.
-     Halftoning it on the same grid is what ties this treatment to the other
-     two — same marks, different subject.                                      */
+     The word as the picture: Cormorant white on black, displaced by a warp that
+     eases out as the section resolves, so it arrives out of distortion rather
+     than fading in. Same grid, same marks, different subject.                 */
   float typeField(vec2 uv, float t){
     float ease = pow(1.0 - clamp(t, 0.0, 1.0), 1.7);
     vec2 p = uv;
@@ -457,59 +356,48 @@
     return texture(uTex, tc).r;
   }
 
-  /* THE MARK ANY GIVEN CELL CARRIES, in cell units.
-     ---------------------------------------------------------------------------
-     Factored out of main because a drop shadow is cast by a MARK, and the marks
-     that fall on a fragment are mostly not its own cell's. Everything a mark's
-     size depends on is a function of its cell id alone — the form sampled at
-     that cell's centre, the tail cut, the gap, and the breathe, which is itself
-     positional — so one id in, one size out, and a fragment can ask about its
-     neighbours on the same terms it asks about itself. */
+  /* THE MARK ANY GIVEN CELL CARRIES, in cell units. Out of main because a
+     shadow is cast by a MARK, and the marks falling on a fragment are mostly
+     not its own cell's. Everything a mark's size depends on is a function of
+     its cell id alone: one id in, one size out, so a fragment asks about its
+     neighbours on the terms it asks about itself. */
   vec2 cellUv(vec2 id){
     return ((id + 0.5) * uCell - 0.5 * uRes) / baseOf();
   }
 
-  /* THE PICTURE, SAMPLED AT ONE CELL. This is the only place the form is ever
+  /* THE PICTURE, SAMPLED AT ONE CELL, and the only place the form is ever
      evaluated. A halftone has exactly one sample per cell by definition, and
-     the whole frame — marks, shadows, ground — is built from this lattice of
-     samples and nothing else. */
+     the whole frame — marks, shadows, ground — is built from this lattice. */
   float formAt(vec2 id){
     float halfH = halfHOf();
     vec2  uvc   = cellUv(id);
     float l = uMode == 0 ? form(uvc, uG)
             : uMode == 1 ? arch(uvc, halfH, uT)
                          : typeField(uvc, uT);
-    /* Cut the tail. A near-constant 2% across a large area is not invisible —
-       it renders as a perfectly regular lattice of isolated marks, i.e.
-       wallpaper across the whole frame and through the headline. Anything this
-       dim carries no form, so it is not dim, it is off. */
+    /* Cut the tail. A near-constant 2% over a large area renders as a perfectly
+       regular lattice of isolated marks — wallpaper across the frame and
+       through the headline. This dim carries no form, so it is off, not dim. */
     return max(l * uGain - 0.06, 0.0) / 0.94;
   }
 
-  /* ...AND EVERY READ OF IT AFTER THE FIRST IS A TEXTURE FETCH.
-     ---------------------------------------------------------------------------
-     A cell's sample is the same for every pixel in that cell, and a fragment
-     shader has no way to know that — asked nine times per pixel it evaluates
-     the form nine times per pixel, which measured 5.4x the whole frame's cost
-     on the software path. So the form is evaluated once per CELL into a small
-     texture and read back here. At a 12px cell that is one evaluation per 144
-     device pixels instead of nine per pixel, which is why the correct nine-tap
-     version is also the fastest this page has ever been.
-
-     The one-cell border is what makes the edge of the frame ordinary: a
-     fragment in the outermost cell asks about a neighbour at -1, and it is
-     there. */
+  /* ...AND EVERY READ AFTER THE FIRST IS A TEXTURE FETCH. A cell's sample is
+     the same for every pixel in it, and a fragment shader cannot know that:
+     asked nine times per pixel it evaluates the form nine times per pixel,
+     measured at 5.4x the frame's cost on the software path. Once per CELL into
+     a small texture, a 12px cell is one evaluation per 144 device pixels, which
+     is why the correct nine-tap version is also the fastest this page has been.
+     The one-cell border makes the frame's edge ordinary: the outermost cell
+     asks about a neighbour at -1, and it is there. */
   vec3 cellAt(vec2 id){
     ivec2 t = clamp(ivec2(id) + 1, ivec2(0), textureSize(uLat, 0) - 1);
     return texelFetch(uLat, t, 0).rgb;
   }
 
-  /* The breathe at one cell. It reaches the mark's SIZE and not the luminance
-     behind it: the form's bright core is saturated, so modulating lum there is
-     swallowed by the clamp and only the falloff would move — size is the one
-     channel a saturated cell still has room in. Two sines at unrelated rates,
-     which is what makes it read as breathing rather than as a loop, and it
-     dies on the closing track's window: the last frame is meant to be still. */
+  /* The breathe reaches the mark's SIZE, not the luminance behind it: the
+     form's bright core is saturated, so modulating lum there is swallowed by
+     the clamp and only the falloff would move. Two sines at unrelated rates, so
+     it reads as breathing rather than as a loop, and it dies on the closing
+     window — the last frame is meant to be still. */
   float breatheAt(vec2 id){
     vec2  uvc  = cellUv(id);
     float wave = sin(uTime * 0.55 + uvc.x * 2.3 + uvc.y * 1.7)
@@ -531,36 +419,20 @@
     float halfH = halfHOf();
 
     /* THE GROUND IS THE SAME PICTURE THE MARKS ARE, AT THE SAME RESOLUTION.
-       ------------------------------------------------------------------------
-       This is the second half of the blockiness, and it is the opposite
-       mistake to the first. The ground was originally snapped to the cell,
-       which painted it in flat cell-sized tiles. The fix was to sample the
-       form at the fragment's own position — continuous, and it did kill the
-       tiles, but it bought a subtler defect: the ground could now resolve
-       detail FINER than a cell, and the marks could not.
-
-       The form has such detail. The lattice's rules are a band about four
-       hundredths of a lattice cell wide — 4px against a 24px halftone cell at
-       2x — so a rule that happens to fall between two mark centres is invisible
-       to every mark and fully visible in the ground. What you get is a smooth
-       vertical hairline standing in open black with no marks anywhere on it,
-       repeating on the lattice's period (base/13, measured at 105px). That is
-       what was left after the shadow was fixed, and it is not a shadow artefact
-       at all — it is the ground drawing something the halftone cannot say.
+       Snapped to the cell it painted flat tiles; sampled at the fragment's own
+       position it killed them and bought the opposite defect — the ground could
+       then resolve detail FINER than a cell, and the marks could not. A lattice
+       rule is ~4px against a 24px cell at 2x, so a rule falling between two
+       mark centres is invisible to every mark and fully visible in the ground:
+       a smooth hairline in open black, repeating on the lattice period (105px).
 
        So the ground is interpolated between the SAME cell samples the marks are
-       made of. Continuous, so no tiles; band-limited to the cell grid, so no
-       hairlines; and the two layers are now provably one picture rather than
-       two renderings of it that agree in the smooth places.
-
-       Smoothstepped before the mix, not raw bilinear: straight bilinear is
-       continuous but kinks at every cell centre, and a field of derivative
-       creases is its own texture. This is C1 and costs two multiplies.
-
-       The four samples come out of the 3x3 the shadow already needs, so the
-       ground is now free — the whole frame costs nine reads of the form where
-       it used to cost two, and nine is simply what a halftone with a shadow
-       and a glow honestly costs. */
+       made of: continuous, so no tiles; band-limited to the cell grid, so no
+       hairlines; two layers provably one picture. Smoothstepped before the mix,
+       because raw bilinear kinks at every cell centre and a field of derivative
+       creases is its own texture — C1 for two multiplies. The four samples come
+       out of the 3x3 the shadow already needs, so the ground is free: nine
+       reads is what a halftone with a shadow and a glow honestly costs. */
     vec3 C[9];
     for (int j = -1; j <= 1; j++){
       for (int i = -1; i <= 1; i++){
@@ -580,178 +452,130 @@
                      qf.y);
 
     /* Signed cell coordinate, -1 to 1, zero at the mark's centre. The abs is
-       what the mark itself needs; the SIGN is what tells a shadow which of its
-       neighbours it is nearest to. */
+       what the mark needs; the SIGN tells a shadow which neighbour it is
+       nearest to. */
     vec2 gs = (fract(q) - 0.5) * 2.0;
     vec2 f  = abs(gs);
 
-    /* The mark stays a TRUE square, sharp corners and all. Easing them into
-       a squircle was a misread: the squareness that needed fixing was the
-       GLOW's, and rounding the mark as well ate its corners until every mark
-       read as a circle. The halftone's whole character is that its marks are
-       square; only the light around them is not. */
+    /* The mark stays a TRUE square. Easing the corners into a squircle was a
+       misread: the squareness that needed fixing was the GLOW's, and rounding
+       the mark ate its corners until every mark read as a circle. Only the
+       light around a mark is not square. */
     float d = max(f.x, f.y);
     float e = markOf(C[4]);
-    /* ONE CLOCK, AND THE PAGE OWNS IT.
-       ------------------------------------------------------------------------
-       The shadow leaving, the feather tightening and the colour draining are
-       not three effects that happen to coincide, they are the same event — the
-       film resolving into its conclusion — so they run off a single number.
-
-       That number is computed in JS and handed down rather than derived from
-       uG here, because the TYPE resolves on it too. A headline still warm cream
-       while the marks behind it have gone white is the same defect as a shadow
-       that lags the colour, and the only way two languages agree on a curve is
-       for one of them to do the arithmetic. It also lets the about page, which
-       plays this film backwards, carry its own window without the shader
-       knowing there is more than one. */
+    /* ONE CLOCK, AND THE PAGE OWNS IT. The shadow leaving, the feather
+       tightening and the colour draining are one event — the film resolving —
+       so they run off one number, computed in JS rather than from uG, because
+       the TYPE resolves on it too and two languages agree on a curve only if
+       one does the arithmetic. It also lets the about page, which plays this
+       film backwards, carry its own window. */
     float resolveU = clamp(uResolve, 0.0, 1.0);
 
-    /* THE FEATHER, and the only place it is argued. A hard step() gives a
-       razor border — correct, and inert. Feathered by a fraction of a cell the
-       marks catch light the way an emulsion does: the small ones in the
-       falloff dissolve into the ground instead of switching off, and the field
-       shimmers as the breathe moves the boundary through the feather rather
-       than snapping a whole pixel. This is the one place the 1-bit contract is
-       knowingly relaxed, and it is relaxed at the EDGE only — the interior is
-       still exactly ink, the ground still exactly paper. No fwidth(): d comes
-       from a fract(), whose derivative is discontinuous at every cell wall, so
-       the analytic footprint is garbage on exactly the pixels the edge runs
-       through. It resolves with everything else, because once the shadow has
-       gone this is the only softness left and 0.20e is still a 4.2px ramp on a
-       24px cell. Floored at half a device pixel — one gs unit is half a cell,
-       so one device pixel is 2/uCell — so the last frame is a hard edge with
-       one pixel of AA at any DPR rather than one that crawls at 1x. */
-    /* The reflection is NOT here, and it was: a depth term inside this feather
-       softened the mark itself. It is a layer over the canvas instead — .deep
-       in index.html — because softening the MARK is the one trade this film
-       refuses. Mirror of the .deep note there; keep the two in step. */
+    /* THE FEATHER, and the only place it is argued. A hard step() is a razor
+       border: correct, and inert. Feathered by a fraction of a cell the small
+       marks in the falloff dissolve into the ground instead of switching off,
+       and the field shimmers as the breathe moves the boundary through it. The
+       one place the 1-bit contract is knowingly relaxed, and only at the EDGE.
+       No fwidth(): d comes from a fract(), whose derivative is discontinuous at
+       every cell wall, so the analytic footprint is garbage on exactly the
+       pixels the edge runs through. Floored at half a device pixel (one gs unit
+       is half a cell, so one device pixel is 2/uCell) so the last frame is one
+       pixel of AA at any DPR rather than an edge that crawls.
+
+       The reflection is NOT here, and it was: a depth term inside this feather
+       softened the mark itself, the one trade this film refuses. It is a layer
+       over the canvas instead — .deep in index.html; keep the two in step. */
     float w     = max(e * mix(0.20, 0.02, resolveU), 1.0 / uCell);
     /* GATED AT ZERO. In an EMPTY cell e is 0, so w is 0 and this would be
        smoothstep(0, 0, d) — spec-undefined for edge0 >= edge1, and on the usual
-       lowering saturate(0/0) gives 0, i.e. mark = 1. It needs d == 0, which
-       needs gs exactly (0,0), which happens at one pixel per cell and ONLY when
-       uCell is an odd integer: uCell is 12 * dpr, so Windows at 125% gives 15
-       and 175% gives 21. Measured on both: the pixel at the predicted phase ran
-       +36.8 above its own cell's median against +1.2 at uCell 12 — a lit
-       speckle in every empty cell, on two of the commonest desktop scalings in
-       the world, invisible on this machine. */
+       lowering saturate(0/0) gives 0, i.e. mark = 1. It needs gs exactly (0,0),
+       one pixel per cell and ONLY when uCell (12 * dpr) is an odd integer:
+       Windows at 125% gives 15, at 175% gives 21. Measured on both, that pixel
+       ran +36.8 above its cell's median against +1.2 at uCell 12 — a lit
+       speckle in every empty cell, on two very common desktop scalings. */
     float mark  = (1.0 - smoothstep(e - w, e + w, d)) * smoothstep(0.0, 0.02, e);
 
 
-    /* A SHADOW BELONGS TO ITS MARK, NOT TO ITS CELL — and it is an
-       OUTSIDE-ONLY thing. Three rejected designs are why this loop is shaped
-       as it is, and all three came back looking plausible:
+    /* A SHADOW BELONGS TO ITS MARK, NOT TO ITS CELL — and it is OUTSIDE-ONLY.
+       Three plausible-looking designs are rejected here:
 
-         · Blur the MARK. d is Chebyshev, so a gradient in it is a gradient in
-           concentric squares: every mark a little pyramid, the field studded
-           leather. A shadow never touches the inside of what casts it.
+         · Blur the MARK. d is Chebyshev, so a gradient in it is concentric
+           squares: every mark a pyramid, the field studded leather.
          · Own cell only. gs wraps at the wall, so an empty cell beside a full
            one got nothing while the fragment one pixel across got the whole
            0.84 halo — an 84% coverage step along every wall, i.e. tiles.
-         · The nine neighbours sharing ONE e. Recorded as a proven no-op, and
-           it was: at equal mark size the fragment is nearest its own mark by
-           construction, so the max is always itself. A neighbour's shadow is
-           only ever about the neighbour being a DIFFERENT SIZE — markOf's job.
+         · The nine sharing ONE e. A no-op: at equal size the fragment is
+           nearest its own mark by construction, so a neighbour's shadow is only
+           ever about it being a DIFFERENT SIZE, which is markOf's job.
 
-       max, NOT sum. Summing nine inverts the lattice at this radius: four
-       marks are near a corner and one near a centre, so corners come out
-       brighter than marks (0.757 against 0.750) — a bright cross at every
-       corner, a dark ring around every mark. A union of shadows is a max,
-       which is also what keeps a shadow off a neighbouring mark.
+       max, NOT sum. Summing nine inverts the lattice at this radius: four marks
+       are near a corner and one near a centre, so corners come out brighter
+       than marks (0.757 against 0.750). A union of shadows is a max, which also
+       keeps a shadow off a neighbouring mark.
 
        3x3 because 0.80e is a fade LENGTH, not a reach: at the largest mark
-       (e = 0.88, 12px cell, one gs unit = 6px) that is 4.2px of fade and about
-       12px of visible glow, two cells. And it stays continuous across a wall —
-       the 3x3 changes by two columns at distance three, where the exponential
-       is at 5% for the largest mark on the page and buried by the max anyway. */
+       (e = 0.88, 12px cell, one gs unit = 6px) that is 4.2px of fade and ~12px
+       of glow, two cells. Continuous across a wall too — the 3x3 changes by two
+       columns at distance three, where the exponential is at 5% and buried by
+       the max anyway. */
     float shade = 0.0;
     for (int j = -1; j <= 1; j++){
       for (int i = -1; i <= 1; i++){
         vec2  off = vec2(float(i), float(j));
-        /* One cell is TWO units of gs, so the neighbour's centre sits at
-           2*off and the point handed to castShadow is gs measured from it. */
+        /* One cell is TWO units of gs, so the neighbour's centre is at 2*off. */
         float en  = markOf(C[(j + 1) * 3 + (i + 1)]);
         /* sg tightens on the resolve clock — the blur is the atmosphere the
-           argument is told through, and the last frame is the conclusion.
-           Floored rather than zeroed because castShadow divides by it. */
+           argument is told through. Floored, not zeroed: castShadow divides by
+           it, and the smoothstep is the same empty-cell gate as mark's. */
         float sgn = mix(0.80 * en, 0.06 * en, resolveU) + 1e-4;
-        /* The gate closes one hole: at en exactly 0 the exponent is 0/0 at the
-           cell's centre pixel, lighting one pixel in every empty cell. */
         shade = max(shade, castShadow(gs - 2.0 * off, en, sgn)
                            * smoothstep(0.0, 0.02, en));
       }
     }
-    /* HELD UNDER FULL, AND THEN IT LEAVES ENTIRELY. 0.90 and not 1.0 because a
-       step blurred by a symmetric kernel is at HALF strength on the edge
-       itself: a shadow beginning at 1.0 is just a bigger square, and the mark
-       has to keep a defined border with its light outside it. (1.0 - resolveU)
-       is the resolve clock, not a switch — tightening sg alone leaves 0.06e,
-       still ~90% opaque against the mark's own edge, a dark seam a pixel or two
-       wide around every square. Multiplied out, the end state is
-       arithmetically shadowless, and it sharpens as it fades. */
+    /* HELD UNDER FULL, THEN GONE ENTIRELY. 0.90 not 1.0, because a step blurred
+       by a symmetric kernel is at HALF strength on the edge itself: a shadow
+       beginning at 1.0 is just a bigger square, and the mark has to keep a
+       defined border with its light outside it. The (1 - resolveU) is the
+       clock, not a switch — tightening sg alone leaves 0.06e, still ~90% opaque
+       against the mark's edge, a dark seam around every square. Multiplied out,
+       the end state is arithmetically shadowless and sharpens as it fades. */
     shade *= 0.90 * (1.0 - resolveU);
 
-    /* The square OR its shadow, whichever is greater. Inside, the square is 1
-       and wins outright, which is what keeps the interior flat and the 1-bit
-       contract intact; outside, the square is 0 and the shadow decays. */
+    /* The square OR its shadow, whichever is greater: inside, the square is 1
+       and wins outright, which keeps the interior flat and the 1-bit contract
+       intact; outside it is 0 and the shadow decays. */
     float cover = max(mark, shade);
 
-    /* One bit per cell everywhere except the feathered edge above. Which two
-       colours those are is the page's business, not the
-       renderer's.
+    /* One bit per cell everywhere but the feathered edge; which two colours
+       those are is the page's business. The ink travels, though — uInk is the
+       cream --field, uInk2 the white --field-end — so the mix at the foot of
+       this ramp is live machinery. It finishes a whole section before the mark
+       closes, deliberately: the argument is toned, the conclusion is not, and
+       uInk2 is WHITE because a resolve landing on a tone has not resolved.
 
-       The ink may travel across the page, though. Where uInk2 differs from
-       uInk the mark bleeds from one to the other as you scroll. They DO
-       differ here — uInk is the cream --field, uInk2 the white --field-end —
-       so this travel is live and the mix at the foot of the ramp is not
-       removable machinery.
-
-       This ran late for a long time — pinned to the CLOSING of the mark
-       (0.86-0.965 above) so the colour and the form arrived together. It no
-       longer does. The resolving now finishes at the top of the finale, one
-       whole section before the form closes, which is a deliberate separation
-       and not a drift: the argument is toned, the conclusion is not, and the
-       last section is meant to be a still white frame rather than a frame
-       still cooling. uInk2 is therefore WHITE, not the cream the ramp passes
-       through — a resolve that lands on a tone has not resolved. */
-    /* KEYED TO THE FRAME, NOT TO THE FORM.
-       Ramping on lum made the warmth radiate out of the arc's own centre —
-       it travelled with the object, so every part of the form at the same
-       brightness was the same colour wherever it sat. What the reference
-       actually does is vertical: the floor of the frame is orange, it passes
-       through yellow, and it is neutral cream by the top. That is light
-       coming from BELOW the picture, and it stays put while the form moves
-       through it. vy is 0 at the floor and 1 at the ceiling. */
+       KEYED TO THE FRAME, NOT TO THE FORM: ramping on lum made the warmth
+       radiate out of the arc's centre, travelling with the object. The
+       reference is vertical — orange at the floor, through yellow, cream by the
+       top: light from BELOW, staying put while the form moves through it. */
     float vy      = clamp((uv.y + halfH) / (2.0 * halfH), 0.0, 1.0);
-    /* THREE STOPS, not two. A straight line from the orange to the cream
-       spends most of the frame in the muddy middle of that line, which is the
-       tan the first attempt produced -- warm, but never actually orange at
-       the floor and never actually yellow at the top. The reference has a
-       distinct yellow BAND: measured up the limb of the arch, G/R climbs
-       0.813 -> 0.83 -> 0.91 -> 0.93 while B/R sits flat near 0.70 and only
-       lifts to 0.785 at the crown. Red first, then yellow, then pale: the
-       middle stop is what makes the yellow read as its own colour rather than
-       as a stage the orange passes through.
+    /* THE FILM IS TONED, NOT MONOCHROME. Sampled off photographs of it running,
+       the marks are a warm cream (#F5E1BA at the crown, #E4C198 mid-limb) on a
+       pitch black ground, so the warmth is carried entirely by the MARK and the
+       hue ramps with brightness — a black-body ramp, dim and orange at uTint,
+       pale as it heats, which reads as lit rather than coloured.
 
-       Derived from the two ends rather than carried as a third uniform -- the
-       page should not have to name a colour it cannot see. */
-    /* THE FILM IS TONED, NOT MONOCHROME. Sampled off photographs of the thing
-       running, the marks are a warm cream (#F5E1BA at the arch's crown,
-       #E4C198 through the mid limb) — the ground is pitch black, so the warmth
-       is carried entirely by the MARK. The hue ramps with brightness, which is
-       what makes it read as lit rather than coloured: a black-body ramp, dim
-       and orange at uTint, pale as it heats, which a flat mark colour cannot
-       fake. The ground below carries a little of the same warm, weighted low,
-       so the light spills off the form instead of stopping at its edge. All of
-       it drains on the resolve clock: the last frame is the palette's own two
-       values with nothing added.
+       THREE STOPS, not two: a straight line from orange to cream spends most of
+       the frame in the muddy middle of it, a tan never actually orange at the
+       floor nor yellow at the top. The reference has a distinct yellow BAND —
+       up the limb, G/R climbs 0.813 -> 0.83 -> 0.91 -> 0.93 while B/R sits flat
+       near 0.70 and lifts to 0.785 only at the crown. The middle stop is
+       derived from the two ends, not carried as a third uniform: the page
+       should not name a colour it cannot see.
 
-       PEAK RED SITS AT A QUARTER HEIGHT, which is smoothstep's own edge0 of
-       0.30 below — at vy = 0 the arch's marks are smallest, and at partial
-       coverage the mix runs ink toward GROUND, so the red came out #4F413E,
-       B/R 0.785, a neutral grey. Held off the floor it lands while the marks
-       are still full strength and stays red as they thin. */
+       PEAK RED SITS AT A QUARTER HEIGHT, the 0.30 edge0 below. At vy = 0 the
+       marks are smallest and partial coverage runs ink toward GROUND, so the
+       red came out #4F413E, a neutral grey; held off the floor it lands while
+       the marks are still full strength. */
     vec3  amber   = mix(uTint, uInk, 0.52);
     float lo      = smoothstep(0.30, 0.52, vy);
     float hi      = smoothstep(0.46, 0.72, vy);
@@ -759,33 +583,24 @@
     vec3  ink     = mix(warm, uInk2, resolveU);
 
     float lowBias = mix(1.0, 0.35, smoothstep(-halfH, halfH, uv.y));
-    /* And the ground under the form carries the same warm, weighted low. This
-       is not decoration: a thinning mark blends toward the ground, so if the
-       ground stays cold the falloff turns grey no matter how red the ink is.
-       Warm ground is what lets the limbs stay orange as they fade out. */
+    /* The ground carries the same warm, weighted low — not decoration: a
+       thinning mark blends toward the ground, so a cold ground turns the
+       falloff grey however red the ink is. Keyed to lumG, the form's own light,
+       so it reads as a lit OBJECT and not a tinted sheet. */
     float bloom   = pow(clamp(lumG, 0.0, 1.0), 0.42) * lowBias;
-    /* Keyed to lumG — the form's own light — which is what makes the ground
-       read as a lit OBJECT rather than as a tinted sheet: brightest along the
-       stroke's spine, falling away to either side. It drains on the resolve
-       clock with everything else. */
     float haze    = bloom * 0.55 * (1.0 - resolveU);
     vec3  gnd     = mix(uPaper, uTint, haze);
 
-    /* SPILL BETWEEN CELLS, which the blur above cannot produce on its own.
-       Every mark is solved inside its own cell and d saturates at the cell
-       wall, so a bright mark's light stops dead at its neighbour's border —
-       widen the kernel and the dots only get rounder while the gaps between
-       them get DARKER, because a mark spread thinner is a mark dimmer. The
-       photographs do the opposite: the gaps inside the bright band carry
-       light and the whole band glows, with the screen still legible in it.
-
-       That light has to come from somewhere outside the cell, so it comes
-       from lum, which is the form itself and knows nothing about the grid.
-       Toward ink rather than toward the warm, because it is the marks'
-       own light: cream where they are cream, orange low in the frame where
-       they are orange. A tight exponent keeps it welded to the form — at
-       the 0.42 the wide haze uses, a nearly-empty cell would still pick up
-       a few percent and the dark would stop being dark. */
+    /* SPILL BETWEEN CELLS, which the blur above cannot produce. Every mark is
+       solved inside its own cell and d saturates at the wall, so its light
+       stops dead at its neighbour's border — widen the kernel and the dots only
+       get rounder while the gaps get DARKER, a mark spread thinner being a mark
+       dimmer. The photographs do the opposite: the gaps inside the bright band
+       carry light and the whole band glows. So the light comes from lum, the
+       form itself, which knows nothing about the grid, and runs toward ink
+       because it is the marks' own. A tight exponent keeps it welded to the
+       form — at the 0.42 the haze uses, a nearly-empty cell picks up a few
+       percent and the dark stops being dark. */
     float spill   = pow(clamp(lumG, 0.0, 1.0), 1.1) * (1.0 - resolveU);
     gnd           = mix(gnd, ink, spill * 0.42);
 
@@ -793,24 +608,22 @@
     fragColor = vec4(mix(gnd, ink, cover), 1.0);
   }`;
 
-  /* THE LATTICE PASS. One texel per cell, and nothing else in it. Built by
-     cutting the main shader at its main() so the two can never drift: same
-     uniforms, same form, same tail cut, by construction rather than by care. */
+  /* THE LATTICE PASS. One texel per cell and nothing else, built by cutting the
+     main shader at its main() so the two can never drift: same uniforms, same
+     form, same tail cut, by construction rather than by care. If the cut
+     misses, slice(0, -1) returns the WHOLE shader minus one character and the
+     lattice program is built with two main()s, surfacing hundreds of lines away
+     as a GLSL redefinition error. The sentinel is literal text including its
+     indentation, so a formatter reaching inside this template is all it takes:
+     say which thing broke, here. */
   const CUT = FRAG.indexOf('  void main(){');
-  /* If the cut ever misses, slice(0, -1) hands back the WHOLE shader minus its
-     last character and the lattice program is built with two main()s in it —
-     which surfaces, several hundred lines away, as a GLSL error about a
-     redefinition. The sentinel is literal text including its indentation, so a
-     formatter reaching inside this template is all it takes. Say which thing
-     broke, here, rather than leaving the compiler to describe the symptom. */
   if (CUT < 0) throw new Error('PTLField: FRAG has no "  void main(){" to cut at');
   const COMMON   = FRAG.slice(0, CUT);
   /* DERIVED FROM THE DECLARATIONS, not kept by hand beside them. A uniform
      added to the shader and to feed() but not to this list gets an undefined
      location, which WebGL treats as null — the write vanishes with no error and
-     the picture is quietly wrong. A stray `uniform` inside a GLSL comment would
-     add a name that resolves to null too, which makes its setters no-ops: the
-     benign direction of the same failure. */
+     the picture is quietly wrong. (A stray `uniform` inside a GLSL comment adds
+     a name that resolves to null too: the benign direction of the same bug.) */
   const UNIFORMS = [...COMMON.matchAll(/uniform\s+\w+\s+(\w+)/g)].map(m => m[1]);
   const FRAG_LAT = COMMON + `void main(){
     /* One cell of border all round, so texel (0,0) is cell (-1,-1). */
@@ -836,27 +649,22 @@
     const gl = canvas.getContext('webgl2', { antialias: false, alpha: false });
     if (!gl) return null;
 
-    /* Without preventDefault() the context can never come back, and a page
-       whose entire picture is one shader would stay blank for the rest of the
-       session while the type kept choreographing over nothing. */
     /* Everything GL lives in build(), because a lost context invalidates every
-       program, uniform location and texture handle at once — restoring means
-       making all of it again. Without preventDefault() the browser never offers
-       to restore at all, and a page whose entire picture is one shader would
-       stay blank for the rest of the session while the type kept choreographing
-       over nothing. */
+       program, location and texture handle at once. Without preventDefault()
+       the browser never offers to restore at all, and a page whose entire
+       picture is one shader would stay blank for the session while the type
+       kept choreographing over nothing. */
     let prog = null, u = {}, tex = null, drawn = null, lost = false;
-    /* The lattice pass and the target it draws into: one texel per cell, plus
-       a cell of border. lw/lh cache its size the way w/h cache the canvas's. */
+    /* The lattice pass and its target: one texel per cell plus a cell of
+       border. lw/lh cache its size the way w/h cache the canvas's. */
     let latProg = null, ul = {}, latTex = null, fbo = null, lw = 0, lh = 0;
-    /* The drawing-buffer size last handed to gl.viewport(). Declared up here so
-       build() can clear it: after a restore the GL state is back at its
-       defaults, and leaving the cache populated would let size() decide there
-       was nothing to re-apply. */
+    /* Last size handed to gl.viewport(). Up here so build() can clear it: after
+       a restore the GL state is back at its defaults, and a populated cache
+       would let size() decide there was nothing to re-apply. */
     let w = 0, h = 0;
     /* Set only if a REBUILD fails — the context came back and would not take
-       the program. Nothing can be drawn again after that, so the page stops
-       asking rather than calling draw() on every scroll frame forever. */
+       the program. Nothing can be drawn after that, so the page stops asking
+       rather than calling draw() on every scroll frame forever. */
     let dead = false;
 
     function link(frag) {
@@ -872,9 +680,8 @@
       gl.attachShader(p, vs);
       gl.attachShader(p, fs);
       gl.linkProgram(p);
-      /* Linked or not, the shader objects have served their purpose: the
-         program holds everything it needs. Left attached they stay resident
-         for the life of the page. */
+      /* Linked or not, the program holds all it needs; left attached the shader
+         objects stay resident for the life of the page. */
       gl.detachShader(p, vs); gl.deleteShader(vs);
       gl.detachShader(p, fs); gl.deleteShader(fs);
       if (!gl.getProgramParameter(p, gl.LINK_STATUS)) {
@@ -892,10 +699,9 @@
     }
 
     function build() {
-      /* On a restore these handles name objects the driver has already
-         destroyed, so deleting them is a formality — but build() is the one
-         place that makes them, and it should be the one place that lets them
-         go. */
+      /* After a restore these handles name objects the driver already
+         destroyed, so deleting them is a formality — but build() makes them and
+         should be the one place that lets them go. */
       if (!gl.isContextLost()) {          // else: two INVALID_OPERATIONs per restore
         if (prog) gl.deleteProgram(prog);
         if (latProg) gl.deleteProgram(latProg);
@@ -910,10 +716,9 @@
 
       latTex = gl.createTexture();
       gl.bindTexture(gl.TEXTURE_2D, latTex);
-      /* NEAREST, and it matters: the value in a texel is a PAIR OF BYTES that
-         together are one number, and the average of two encodings is not the
-         encoding of the average. The interpolation the ground wants happens in
-         the shader, on decoded values. */
+      /* NEAREST, and it matters: a texel is a byte PAIR, and the average of two
+         encodings is not the encoding of the average. The ground interpolates
+         in the shader, on decoded values. */
       gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
       gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
       gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
@@ -937,13 +742,9 @@
       w = h = 0;                        // and so did the viewport
     }
     /* Every caller reads this as "a field, or null" and branches once. The
-       restore path already honours that — it catches and marks the field dead
-       — but the FIRST build did not, so a driver that takes the context and
-       then refuses the program threw out of mount(), past the null check, and
-       took the rest of the calling script with it. On the front page that
-       aborts before the choreography is armed and leaves the reader the static
-       no-js document; the two failures are the same failure, and the page
-       already knows how to survive one of them. */
+       restore path honours that; the FIRST build did not, so a driver that took
+       the context and then refused the program threw out of mount(), past the
+       null check, and took the rest of the calling script with it. */
     try {
       build();
     } catch (e) {
@@ -953,10 +754,9 @@
 
     canvas.addEventListener('webglcontextlost', e => { e.preventDefault(); lost = true; });
     canvas.addEventListener('webglcontextrestored', () => {
-      /* An exception thrown here would escape into an event handler, where
-         nothing is waiting for it, and leave `lost` true forever — the picture
-         gone with no record of why. Catch it, say so once, and mark the field
-         dead so the page can stop driving it. */
+      /* An exception here escapes into an event handler where nothing is
+         waiting for it, leaving `lost` true forever — the picture gone with no
+         record of why. Say so once, and mark the field dead. */
       try {
         build();
         lost = false;
@@ -980,7 +780,7 @@
       c.fillStyle = '#fff';
       c.textAlign = 'center'; c.textBaseline = 'middle';
       /* Overflow the frame on purpose — the reference letterforms are cropped
-         hard by the edges, and that is what gives a thin serif weight at scale. */
+         hard by the edges, which is what gives a thin serif weight at scale. */
       let size = 520;
       c.font = `300 ${size}px Cormorant, serif`;
       const w0 = c.measureText(word).width;
@@ -999,9 +799,9 @@
       gl.viewport(0, 0, w, h);
     }
 
-    /* Both programs read the same picture, so both take the same uniforms.
-       Handed the program's OWN location map, because a uniform location belongs
-       to a program and using one against the other silently writes nothing. */
+    /* Both programs read the same picture, so both take the same uniforms —
+       each handed its OWN location map, because a location belongs to a program
+       and using one against the other silently writes nothing. */
     function feed(p, uu, t, o, cell, mode) {
       gl.useProgram(p);
       gl.uniform1i(uu.uTex, 0);
@@ -1036,20 +836,17 @@
     function draw(t, o) {
       if (lost || dead) return;
       o = o || {};
-      /* ONE READING OF EACH. The cell size below sizes the lattice texture and
-         is also what feed() writes into uCell — if the two ever disagreed the
-         one-cell border invariant breaks and every fragment's 3x3 reads the
-         wrong texels, a whole-frame corruption out of two lines that look
-         independent. So it is computed here and handed to both. */
+      /* ONE READING OF EACH. This cell size sizes the lattice texture AND is
+         what feed() writes into uCell; if the two disagreed the one-cell border
+         invariant breaks and every fragment's 3x3 reads the wrong texels — a
+         whole-frame corruption out of two lines that look independent. */
       const dpr = Math.min(root.devicePixelRatio || 1, 2);
       const cell = (o.cell != null ? o.cell : 12) * dpr;
       size(dpr);
       const mode = MODES[o.mode || opt.mode] || 0;
       if (mode === 2 && o.word) setWord(o.word);
 
-      /* One texel per cell, plus a cell of border either side, so a fragment
-         in the outermost cell can still ask about a neighbour beyond the frame
-         and get an answer rather than a clamp. */
+      /* One texel per cell, plus the cell of border cellAt() relies on. */
       const nw = Math.ceil(w / cell) + 2, nh = Math.ceil(h / cell) + 2;
       if (nw !== lw || nh !== lh) {
         lw = nw; lh = nh;
@@ -1076,11 +873,9 @@
       gl.drawArrays(gl.TRIANGLES, 0, 3);
     }
 
-    /* isLost is the RECOVERABLE half of isDead: the context has gone but the
-       browser may still offer it back, and draw() returns immediately for
-       both. The page needs the two apart: dead is terminal, and is where it
-       stops asking for good, whereas lost is where it stops asking UNTIL the
-       restore event — which is its cue to start again. */
+    /* isLost is the RECOVERABLE half of isDead: draw() returns immediately for
+       both, but the page needs them apart — dead is terminal, lost is where it
+       stops asking UNTIL the restore event, its cue to start again. */
     return { draw, setWord, gl, canvas, isDead: () => dead, isLost: () => lost };
   }
 

--- a/src/ptl-field.js
+++ b/src/ptl-field.js
@@ -38,6 +38,33 @@
     ASPECT: 1.78,            // the long-side normalisation, uRes.x / 1.78
   };
 
+  /* ---- THE FIELD'S VOCABULARY ----------------------------------------------
+     draw() takes colours as normalised triples and is driven by curves the page
+     computes, so turning a stylesheet token into something it accepts is part of
+     using it — the same reason CLOSE is published above. Exported because BOTH
+     pages need them and about.html loads only this file.
+
+     They were written twice, and the two hex3s had already diverged: this one
+     expands three-digit hex and about.html's guarded a missing token, so
+     `--paper: #000` would have rendered on the front page and handed the shader
+     [NaN, NaN, NaN] here. Both guards are kept below; that is the whole point of
+     there being one copy. */
+  const clamp  = x => (x < 0 ? 0 : x > 1 ? 1 : x);
+  const lerp   = (a, b, u) => a + (b - a) * u;
+  const smooth = (a, b, x) => { const u = clamp((x - a) / (b - a)); return u * u * (3 - 2 * u); };
+  const hex3 = h => {
+    const v = (h || '').trim().replace('#', '');
+    const n = v.length === 3 ? v.split('').map(c => c + c).join('') : v;
+    return [0, 2, 4].map(i => parseInt(n.slice(i, i + 2), 16) / 255);
+  };
+  /* Both pages travel the type from --ink to --field-end on the resolve clock,
+     which is the field's own pair of tokens, so the mix belongs with them. */
+  const mixHex = (a, b, t) => {
+    const A = hex3(a), B = hex3(b);
+    const c = i => Math.round((A[i] + (B[i] - A[i]) * t) * 255);
+    return 'rgb(' + c(0) + ',' + c(1) + ',' + c(2) + ')';
+  };
+
   const VERT = `#version 300 es
   void main(){
     vec2 p = vec2((gl_VertexID << 1) & 2, gl_VertexID & 2);
@@ -750,5 +777,5 @@
     return { draw, gl, canvas, isDead: () => dead, isLost: () => lost };
   }
 
-  root.PTLField = { mount, CLOSE };
+  root.PTLField = { mount, CLOSE, clamp, lerp, smooth, hex3, mixHex };
 })(window);

--- a/src/ptl-page.js
+++ b/src/ptl-page.js
@@ -429,20 +429,24 @@
       finC.style.transform =
         `translate(-50%,${(rY + finB.offsetHeight + ctaGap).toFixed(1)}px)`;
       for (const el of [b.l1, b.l2, b.l3]) fadeLine(el, 1, 0, H);
-      /* The button is simply present: its arrival IS the motion. */
-      cta.style.opacity = '1';
-      cta.style.transform = 'none';
-      cta.style.pointerEvents = 'auto';
-      /* AND IT HAS TO BE LIVE. inert is set only in floatCta, which this branch
-         returns before reaching — so a reader who scrolled into the finale with
-         motion on and THEN turned reduce on was handed a full-opacity button,
-         pointer-events auto, that could not be clicked, tapped or focused.
-
-         ctaU and ctaSettling go with it: leaving ctaSettling true strands
-         tick()'s `arriving` re-arm permanently high — an unbounded rAF running
-         two fullscreen GL passes a frame, under the exact preference the still
-         frame exists to honour. */
-      cta.inert = false;
+      /* The button is simply present: its arrival IS the motion. Guarded like
+         measure() and floatCta() guard it — this branch was the one place in
+         the file that assumed the element exists. */
+      if (cta) {
+        cta.style.opacity = '1';
+        cta.style.transform = 'none';
+        cta.style.pointerEvents = 'auto';
+        /* AND IT HAS TO BE LIVE. inert is set only in floatCta, which this
+           branch returns before reaching — so a reader who scrolled into the
+           finale with motion on and THEN turned reduce on was handed a
+           full-opacity button, pointer-events auto, that could not be clicked,
+           tapped or focused. */
+        cta.inert = false;
+      }
+      /* ctaU and ctaSettling go with it, element or not: leaving ctaSettling
+         true strands tick()'s `arriving` re-arm permanently high — an unbounded
+         rAF running two fullscreen GL passes a frame, under the exact
+         preference the still frame exists to honour. */
       ctaU = 1;
       ctaSettling = false;
       return;
@@ -547,12 +551,13 @@
      stylesheet removes the animation, so there is nothing to wake. */
   function wakeCaret() {
     if (reduce) return;
-    const cur = blocks[blocks.length - 1] && blocks[blocks.length - 1].cur;
-    if (!cur || !cur.isConnected) return;
-    if (cur.getAnimations().length) return;      // still blinking; leave it be
-    cur.style.animation = 'none';
-    void cur.offsetWidth;                        // reflow, or the restart is a no-op
-    cur.style.animation = '';
+    /* Not `cur`: that is the pointer's eased position, module-level. */
+    const caret = blocks[blocks.length - 1] && blocks[blocks.length - 1].cur;
+    if (!caret || !caret.isConnected) return;
+    if (caret.getAnimations().length) return;    // still blinking; leave it be
+    caret.style.animation = 'none';
+    void caret.offsetWidth;                      // reflow, or the restart is a no-op
+    caret.style.animation = '';
   }
 
   addEventListener('pointermove', e => {

--- a/src/ptl-page.js
+++ b/src/ptl-page.js
@@ -111,44 +111,27 @@
     return [0, 2, 4].map(i => parseInt(n.slice(i, i + 2), 16) / 255);
   };
   let INK = [1, 1, 1], INK2 = [1, 1, 1], PAPER = [0, 0, 0], TINT = [0, 0, 0];
-  /* 1 where the ground is PAPER and 0 where it is a room, read off the paper's
-     own luminance rather than off the variant name — a palette that inverts
-     the ground should not also have to remember to say so. Smoothed rather
-     than a threshold so a genuinely mid ground lands between the two models
-     instead of snapping to whichever side of 0.5 it fell on. */
-  let PRINT = 0;
   /* The writing's own two ends. TYPE_A is what the type is while the film is
      toned; TYPE_B is where it lands, which is the same place the MARKS land —
-     --field-end. Tying it to that token rather than to a literal white is what
-     makes this correct in all three variants without a branch: on the two pale
-     grounds --ink already IS --field-end, so the travel is a no-op. */
+     --field-end. Tied to that token rather than to a literal white so the type
+     and the marks can never arrive at different whites. The two DIFFER here —
+     --ink is #f4eada and --field-end is #ffffff — so the travel is real and
+     the mixHex below is load-bearing. */
   let TYPE_A = '#ffffff', TYPE_B = '#ffffff';
-  /* The drop shadow is the indigo variant's alone — see uShadow in the
-     renderer. Read once: the variant cannot change without a reload. */
-  const SHADOW = document.documentElement.dataset.v ? 0 : 1;
-  /* The toning is variation 4's alone to lose. uShadow already goes off for
-     every variation but the first, because a dark halo on light paper is a
-     smudge; the RAMP is a separate question, and the two pale grounds keep
-     theirs. Read once: the variation cannot change without a reload. */
-  const TONE   = /^[34]$/.test(document.documentElement.dataset.v || '') ? 0 : 1;
   const palette = () => {
     const cs = getComputedStyle(document.documentElement);
     /* --field, not --ink: the film's colour and the writing's colour are
-       allowed to differ, and in variation 3 they do. */
+       allowed to differ, and they do — the film runs cream, the copy runs
+       --ink. Do not "fix" this to --ink. */
     INK   = hex3(cs.getPropertyValue('--field') || '#ffffff');
     INK2  = hex3(cs.getPropertyValue('--field-end') || cs.getPropertyValue('--field') || '#ffffff');
     PAPER = hex3(cs.getPropertyValue('--paper') || '#000000');
-    /* Falls back to the paper itself, which makes the tint a no-op rather
-       than a guess if a variant does not define one. */
-    TINT  = hex3(cs.getPropertyValue('--tint') || cs.getPropertyValue('--paper') || '#000000');
+    TINT  = hex3(cs.getPropertyValue('--tint') || '#000000');
     /* Read from the ROOT rule, not from the element we are about to write
        --ink-live onto — reading back our own output would ratchet the type
        toward white a frame at a time and never come back. */
     TYPE_A = (cs.getPropertyValue('--ink') || '#ffffff').trim();
     TYPE_B = (cs.getPropertyValue('--field-end') || TYPE_A).trim();
-    const pl = 0.2126 * PAPER[0] + 0.7152 * PAPER[1] + 0.0722 * PAPER[2];
-    PRINT = clamp((pl - 0.25) / 0.30);
-    PRINT = PRINT * PRINT * (3 - 2 * PRINT);
   };
 
   /* WHERE THE MARK ENDS UP, as the field publishes it. Three things in this
@@ -181,21 +164,8 @@
      An ease-OUT: it leaves at speed and spends the rest of the window
      arriving. K is the whole of the aggression — 2 is the ordinary ease-out,
      4 was too abrupt to read as a settle. */
-  /* EXCEPT ON THE BLUE, WHICH KEEPS THE OLD WINDOW.
-     Everything above is why the window opens where it does on the dark
-     variant: the argument is told in the warm and only the answer is white, so
-     the drain has to start early enough to be a passage rather than a switch.
-     The blue is not making that argument. Its colour is the state of the
-     thing being described — "the whole argument is blue and the colour
-     resolves at exactly the moment the form does" — so draining it from the
-     fourth beat spends it before the section that most wants it. That variant
-     therefore keeps what it had before the clock moved into JS: smoothstep
-     over the CLOSING of the mark, 0.885 to 0.985, symmetric, and late.
-
-     Read once — the variation cannot change without a reload. */
-  const LATE  = document.documentElement.dataset.v === '3';
-  const RES_A = LATE ? 0.885 : 4 / 6;
-  const RES_B = LATE ? 0.985 : C.TO;
+  const RES_A = 4 / 6;
+  const RES_B = C.TO;
   const RES_K = 2.5;
   /* AND IT LANDS EARLIER ON A PHONE. The same window, slid back so that it
      CLOSES where it used to open — the top of PRICE. On a wide frame the drain
@@ -204,20 +174,14 @@
      frame, and carrying them to the final mark meant the ending had to
      out-shout the film instead of following it. So the phone spends the colour
      by the line that names what the company does, and the last two beats are
-     already white.
-
-     Not applied to the blue: its colour is the state of the thing being
-     described rather than a passage, and it resolves with the form by
-     construction — see the note above. */
+     already white. */
   const RES_SPAN = C.TO - 4 / 6;
   const resolveAt = (g) => {
-    const mob = phone && !LATE;
-    const a = mob ? 4 / 6 - RES_SPAN : RES_A;
-    const b = mob ? 4 / 6 : RES_B;
+    const a = phone ? 4 / 6 - RES_SPAN : RES_A;
+    const b = phone ? 4 / 6 : RES_B;
     const u = clamp((g - a) / (b - a));
-    /* The old one was a smoothstep, which eases in AND out; the dark
-       variant's leaves at speed and coasts. Keeping both rather than fitting
-       one curve to two intentions.
+    /* Two curves, because the two windows want opposite things. The wide
+       frame's is an ease-OUT: it leaves at speed and coasts into the close.
 
        The phone's runs the other way — ease IN, the same exponent mirrored.
        Its window is short and lands two beats early, and an ease-out spends
@@ -225,9 +189,8 @@
        reader had scrolled through the beat it belongs to. Easing in holds the
        warm most of the way and then goes, which is a film ending rather than
        a light being switched off. */
-    return LATE ? u * u * (3 - 2 * u)
-         : mob  ? Math.pow(u, RES_K)
-                : 1 - Math.pow(1 - u, RES_K);
+    return phone ? Math.pow(u, RES_K)
+                 : 1 - Math.pow(1 - u, RES_K);
   };
 
   const mixHex = (a, b, t) => {
@@ -982,8 +945,7 @@
         ? [FLOOR[0], -FLOOR[3] + (FLOOR[1] + FLOOR[3]) * end, FLOOR[2], FLOOR[3]]
         : FLOOR,
       lift: lift(),
-      cell: 12, gap: 0.12, gain: 1.0, fov: 0.70, shadow: SHADOW, tone: TONE,
-      print: PRINT,
+      cell: 12, gap: 0.12, gain: 1.0, fov: 0.70,
       mouse: cur, act, ink: INK, ink2: INK2, paper: PAPER, tint: TINT,
       time: clock, amb: ambient(), resolve: res,
     });

--- a/src/ptl-page.js
+++ b/src/ptl-page.js
@@ -737,13 +737,10 @@
     if (ticking) return;
     ticking = requestAnimationFrame(function step(ts) {
       ticking = 0;
-      /* Clamped, because a backgrounded tab hands back one enormous delta on
-         return and the field would jump a second and a half of sine. */
-      /* The clamp was written for the tab-return delta, but applied to every
-         frame it DILATED TIME on exactly the devices already struggling: at
-         15fps the ambient clock ran at 0.72 s/s. Only a genuinely absurd gap
-         is a returning tab; everything else is a slow frame and should count
-         for what it was. */
+      /* Clamped for the one enormous delta a backgrounded tab hands back, and
+         ONLY that: a gap past 0.5s is a returning tab, everything else is a
+         slow frame. Applied to every frame it dilated time on the devices
+         already struggling — at 15fps the ambient clock ran at 0.72 s/s. */
       const raw = lastTs ? (ts - lastTs) / 1000 : 0.016;
       const dt  = raw > 0.5 ? 0.016 : Math.min(raw, 0.25);
       lastTs = ts;
@@ -781,14 +778,11 @@
   });
 
   /* ---- the frame ---------------------------------------------------------
-     `typeof`, not a truthiness check: if the request for ptl-field.js failed,
-     PTLField is not a global holding undefined, it is an undeclared name, and
-     `PTLField && …` throws a ReferenceError rather than short-circuiting. It
-     threw here, mid-file, which is survivable — the no-js document was still
-     in place — except that the body had already been stretched to the film's
-     full height on the way past, leaving the fallback as one screen of words
-     at the top of a very long empty page. Nothing is committed to now until
-     the mount has been attempted. */
+     `typeof`, not truthiness: on a failed load PTLField is an undeclared name,
+     so `PTLField && …` throws a ReferenceError rather than short-circuiting.
+     It threw here, after the body had already been stretched to the film's
+     full height — leaving the fallback as one screen of words at the top of a
+     very long empty page. Nothing is committed to until the mount is done. */
   const field = typeof PTLField !== 'undefined'
     ? PTLField.mount(document.getElementById('c'), { mode: 'form' })
     : null;

--- a/src/ptl-page.js
+++ b/src/ptl-page.js
@@ -69,6 +69,15 @@
   latchLVH();
   const filmLen = () => Math.max((S.length * PER - 1) * LVH, 1);
 
+  /* THESE ARE PTLField'S TOO, AND THIS FILE KEEPS ITS OWN ON PURPOSE.
+     about.html takes clamp/lerp/smooth/hex3/mixHex off PTLField, because nothing
+     in that file runs without the field. This one does: with no renderer the
+     choreographed type still carries the whole argument against a plain ground
+     (see the mount below), and every line of that path goes through clamp and
+     mixHex. Sourcing them from a script that may not have loaded would trade a
+     designed-for degradation for a page that throws — which it has done before,
+     after `no-js` was already off the body. Keep the bodies identical to the
+     ones in ptl-field.js; that is the only coupling here. */
   const clamp    = v => (v < 0 ? 0 : v > 1 ? 1 : v);
   const outCubic = v => 1 - Math.pow(1 - v, 3);
   /* Quadratic out, cubic in. A cubic exit spends most of its time doing nothing
@@ -80,7 +89,7 @@
   /* The palette lives in CSS so the page and the field cannot disagree about
      it; the renderer is handed whatever the stylesheet resolved. */
   const hex3 = h => {
-    const v = h.trim().replace('#', '');
+    const v = (h || '').trim().replace('#', '');
     const n = v.length === 3 ? v.split('').map(c => c + c).join('') : v;
     return [0, 2, 4].map(i => parseInt(n.slice(i, i + 2), 16) / 255);
   };

--- a/src/ptl-page.js
+++ b/src/ptl-page.js
@@ -27,7 +27,6 @@
     return {
       head:   sec.querySelector('h1,h2').textContent.trim(),
       body:   p ? p.textContent.trim() : '',
-      key:    sec.dataset.key || '',
       /* Per-beat timing; everything else takes the defaults. */
       win:    { in: pair(sec.dataset.in, [0.02, 0.21]),
                 out: pair(sec.dataset.out, [0.76, 0.22]) },
@@ -632,7 +631,7 @@
      after the body had been stretched to the film's full height — one screen of
      words atop a very long empty page. Nothing is committed until the mount. */
   const field = typeof PTLField !== 'undefined'
-    ? PTLField.mount(document.getElementById('c'), { mode: 'form' })
+    ? PTLField.mount(document.getElementById('c'))
     : null;
   /* A null field is not a failure worth falling back over: WebGL2 is
      unavailable, and the choreographed type carries the whole argument against
@@ -751,7 +750,7 @@
          — only the ambient clock was disabled — and the closing ring's bright
          arc swept up through a lockup reduce pins in place, putting 86% of the
          verb's ink under 4.5:1. */
-      g: reduce ? 1 : p, section: idx, word: S[idx].key,
+      g: reduce ? 1 : p,
       /* The keep-out band is for copy on the floor. On a phone there is none
          until the ending, so it OPENS on the ending's own ramp and the film
          gets the whole frame back for the argument itself.
@@ -770,7 +769,7 @@
         ? [FLOOR[0], -FLOOR[3] + (FLOOR[1] + FLOOR[3]) * end, FLOOR[2], FLOOR[3]]
         : FLOOR,
       lift: lift(),
-      cell: 12, gap: 0.12, gain: 1.0, fov: 0.70,
+      cell: 12, gap: 0.12, gain: 1.0,
       mouse: cur, act, ink: INK, ink2: INK2, paper: PAPER, tint: TINT,
       time: clock, amb: ambient(), resolve: res,
     });

--- a/src/ptl-page.js
+++ b/src/ptl-page.js
@@ -1,23 +1,16 @@
 /* ============================================================================
    PTL — the page
    ----------------------------------------------------------------------------
-   Six beats of an argument, choreographed against scroll over a field drawn by
-   ptl-field.js. Scroll is the only clock the ARGUMENT runs on: every position
-   on this page is a pure function of scrollY, so there is nothing to seek,
-   buffer or decode, and dragging the scrollbar backwards runs the film
-   backwards exactly.
+   Six beats of an argument choreographed against scroll over a field drawn by
+   ptl-field.js. Every position is a pure function of scrollY: nothing to seek
+   or decode, and scrubbing backwards runs the film backwards exactly.
 
-   There is a second clock, and it drives texture only. The field breathes on a
-   real-time clock so that a page nobody is touching is alive rather than a
-   screenshot, and scrolling makes that clock run faster. It reaches exactly one
-   thing — the size of the halftone marks — and nothing that decides where a
-   word sits can read it, so the two clocks cannot disagree about anything that
-   matters. See "the ambient clock" below.
+   A second clock drives texture only, and cannot disagree with the first —
+   see "the ambient clock" below.
 
-   The copy is NOT held here. It lives in index.html as ordinary semantic HTML
-   and is read out of the DOM below, so a crawler, a link preview and a screen
-   reader all get the argument even though not one visible word on this page is
-   in the source at that position.
+   The copy is NOT held here. It lives in index.html as semantic HTML and is
+   read out of the DOM, so crawlers, link previews and screen readers get the
+   argument even though no visible word is in the source at that position.
    ========================================================================== */
 (function () {
   'use strict';
@@ -35,8 +28,7 @@
       head:   sec.querySelector('h1,h2').textContent.trim(),
       body:   p ? p.textContent.trim() : '',
       key:    sec.dataset.key || '',
-      /* Per-beat timing, when a beat needs it. Everything else uses the
-         defaults below. */
+      /* Per-beat timing; everything else takes the defaults. */
       win:    { in: pair(sec.dataset.in, [0.02, 0.21]),
                 out: pair(sec.dataset.out, [0.76, 0.22]) },
       finale: sec.hasAttribute('data-finale'),
@@ -45,43 +37,27 @@
   });
 
   const PER = 2.0;                       // viewport-heights of scroll per section
-  /* Scroll the FILM does not use, appended after it. The last thing the page
-     does is hold a still frame while the one action it offers surfaces, and
-     that beat is made of scroll — there is no other clock the reader controls.
-     Six sections' worth of scroll was nowhere near enough of it: the mark
-     stops closing with only a fifth of the last section left, and that fifth
-     has to carry a pause long enough to read as an ending, the button's
-     arrival, and a little air after it.
-
-     Note that this does not slow the film down. `film` below is the document
-     height MINUS this tail, so every section still gets exactly PER
-     viewport-heights and every cue lands where it always did; the tail is
-     purely extra distance at the bottom, where nothing is moving anyway. */
+  /* Scroll the FILM does not use, appended after it: the page ends on a held
+     still frame while the one action it offers surfaces, and that beat is made
+     of scroll because the reader controls no other clock. It does not slow the
+     film — `film` below is the document height MINUS this, so every cue lands
+     where it always did and the tail is dead distance at the bottom. */
   const TAIL = 0.71;                     // viewport-heights, after the film ends
 
   /* THE FILM'S LENGTH IS NOT A FUNCTION OF THE LIVE VIEWPORT.
      ------------------------------------------------------------------------
-     The body's height is set once, in `vh`, which on a phone resolves to the
-     LARGE viewport — the one with the browser chrome retracted — and never
-     changes again. innerHeight does: the URL bar hides and returns as you
-     scroll, by 56-81px. So `film = const - TAIL*innerHeight` moved under the
-     reader, and with it `p = scrollY/film`, which is the clock EVERYTHING on
-     this page is a pure function of.
+     The body's height is set once in `vh` — on a phone the LARGE viewport — and
+     never changes. innerHeight does: the URL bar hides and returns by 56-81px.
+     A film measured against it moves under the reader, and with it
+     `p = scrollY/film`, the clock EVERYTHING here is a pure function of.
+     Sixteen defects were that one line: the closing link fell to opacity 0.137
+     with no scroll at all and full opacity became unreachable; a resize flipped
+     the section index with dy = 0; rotation rescaled the clock by up to 2.16x.
 
-     Sixteen separate defects were that one line. The toolbar returning at the
-     bottom took the closing link from opacity 1.000 to 0.137 with no scroll
-     at all, and put full opacity permanently out of reach (it needs the
-     chrome under ~25 CSS px; iOS Safari's bar is 81). A resize near a section
-     boundary flipped the section index with dy = 0. Rotation and folding
-     rescaled the clock by up to 2.16x.
-
-     So the film is measured against a latched large-viewport height instead.
-     It is re-latched only when the WIDTH changes, which is what distinguishes
-     a real orientation change from the toolbar sliding.
-
-     NOT `dvh`: measured, that is six times worse, because the document's own
-     height then tracks the chrome too. The film's length simply must not be a
-     function of the live viewport. */
+     So it is measured against a latched large-viewport height, re-latched only
+     on a WIDTH change — which is what tells a real orientation change from the
+     toolbar sliding. NOT `dvh`: six times worse measured, because the
+     document's own height then tracks the chrome too. */
   let LVH = 0;
   function latchLVH() {
     const p = document.createElement('div');
@@ -96,99 +72,75 @@
 
   const clamp    = v => (v < 0 ? 0 : v > 1 ? 1 : v);
   const outCubic = v => 1 - Math.pow(1 - v, 3);
-  /* Quadratic on the way out, cubic in. A cubic exit spends most of its time
-     doing nothing visible, so the copy sat still and then lurched off in the
-     last few percent of the section. */
+  /* Quadratic out, cubic in. A cubic exit spends most of its time doing nothing
+     visible, so the copy sat still then lurched off in the last few percent. */
   const inQuad = v => v * v;
   const lerp   = (a, b, u) => a + (b - a) * u;
   const smooth = (a, b, x) => { const u = clamp((x - a) / (b - a)); return u * u * (3 - 2 * u); };
 
-  /* The palette lives in CSS so the page and the field can never disagree
-     about it; the renderer is handed whatever the stylesheet resolved. */
+  /* The palette lives in CSS so the page and the field cannot disagree about
+     it; the renderer is handed whatever the stylesheet resolved. */
   const hex3 = h => {
     const v = h.trim().replace('#', '');
     const n = v.length === 3 ? v.split('').map(c => c + c).join('') : v;
     return [0, 2, 4].map(i => parseInt(n.slice(i, i + 2), 16) / 255);
   };
   let INK = [1, 1, 1], INK2 = [1, 1, 1], PAPER = [0, 0, 0], TINT = [0, 0, 0];
-  /* The writing's own two ends. TYPE_A is what the type is while the film is
-     toned; TYPE_B is where it lands, which is the same place the MARKS land —
-     --field-end. Tied to that token rather than to a literal white so the type
-     and the marks can never arrive at different whites. The two DIFFER here —
-     --ink is #f4eada and --field-end is #ffffff — so the travel is real and
-     the mixHex below is load-bearing. */
+  /* The writing's two ends: TYPE_A while the film is toned, TYPE_B where it
+     lands — --field-end, the same token the MARKS land on, so type and marks
+     can never arrive at different whites. They DIFFER (--ink #f4eada against
+     #ffffff), so the travel is real and mixHex below is load-bearing. */
   let TYPE_A = '#ffffff', TYPE_B = '#ffffff';
   const palette = () => {
     const cs = getComputedStyle(document.documentElement);
-    /* --field, not --ink: the film's colour and the writing's colour are
-       allowed to differ, and they do — the film runs cream, the copy runs
-       --ink. Do not "fix" this to --ink. */
+    /* --field, not --ink: the film's colour and the writing's are allowed to
+       differ, and do — the film runs cream. Do not "fix" this to --ink. */
     INK   = hex3(cs.getPropertyValue('--field') || '#ffffff');
     INK2  = hex3(cs.getPropertyValue('--field-end') || cs.getPropertyValue('--field') || '#ffffff');
     PAPER = hex3(cs.getPropertyValue('--paper') || '#000000');
     TINT  = hex3(cs.getPropertyValue('--tint') || '#000000');
-    /* Read from the ROOT rule, not from the element we are about to write
-       --ink-live onto — reading back our own output would ratchet the type
-       toward white a frame at a time and never come back. */
+    /* Read from the ROOT rule, not the element we write --ink-live onto —
+       reading back our own output would ratchet the type toward white a frame
+       at a time and never come back. */
     TYPE_A = (cs.getPropertyValue('--ink') || '#ffffff').trim();
     TYPE_B = (cs.getPropertyValue('--field-end') || TYPE_A).trim();
   };
 
-  /* WHERE THE MARK ENDS UP, as the field publishes it. Three things in this
-     file are pinned to the close — the resolve window's far edge, the line
-     that has to stay clear of the mark, and the flag that shuts the ambient
-     loop down once the frame is final — and all three used to carry 0.965 as
-     their own literal. The field owns that geometry, and the note above CLOSE
-     in ptl-field.js records what happened last time the two came apart.
-
-     The fallback only matters if ptl-field.js failed to load, in which case
-     there is no mark to clear, nothing to draw, and no value to be wrong. */
+  /* WHERE THE MARK ENDS UP, as the field publishes it. The resolve window's far
+     edge, the line that must stay clear of the mark and the flag that shuts the
+     ambient loop down all read this; they each carried 0.965 as a literal once,
+     and drifted. The field owns the geometry — see CLOSE in ptl-field.js. The
+     fallback matters only if that file failed to load, when there is no mark to
+     clear and no value to be wrong. */
   const C = (typeof PTLField !== 'undefined' && PTLField.CLOSE) ||
             { FROM: 0.86, TO: 0.965, R: 0.27, DR: 0.24, CY: 0.02, BW: 0.045, ASPECT: 1.78 };
 
   /* THE RESOLVE CLOCK — the one the shader used to own.
      ------------------------------------------------------------------------
-     It moved up here because the TYPE resolves on it too, and two languages
-     agree on a curve only if one of them does the arithmetic. Both edges are
-     named positions in the argument rather than durations: it opens at the top
-     of PRICE — "Predictive Text Labs teaches machines to forecast so they can
-     commit to decisions that matter.", the line that names what the company
-     actually does — and closes exactly where the mark finishes
-     closing, so the picture and the writing arrive at the same instant.
-
-     Four beats of toned film, then it resolves. The argument is told in the
-     warm; only the answer is white. It is a short window for that reason —
-     0.30 of the page against 0.47 when it opened a beat earlier — so the same
-     K reads faster here than it did there.
-
-     An ease-OUT: it leaves at speed and spends the rest of the window
-     arriving. K is the whole of the aggression — 2 is the ordinary ease-out,
-     4 was too abrupt to read as a settle. */
+     It lives here because the TYPE resolves on it too, and two languages agree
+     on a curve only if one of them does the arithmetic. Both edges are named
+     positions, not durations: it opens at the top of PRICE — the line that
+     names what the company does — and closes exactly where the mark finishes
+     closing, so picture and writing arrive together. Four beats of toned film,
+     then the answer in white. K is the whole of the aggression: 2 is the
+     ordinary ease-out, 4 was too abrupt to read as a settle. */
   const RES_A = 4 / 6;
   const RES_B = C.TO;
   const RES_K = 2.5;
-  /* AND IT LANDS EARLIER ON A PHONE. The same window, slid back so that it
-     CLOSES where it used to open — the top of PRICE. On a wide frame the drain
-     is a passage the reader watches through the last two beats; on a phone the
-     colour and the depth blur under it are the loudest things in a small
-     frame, and carrying them to the final mark meant the ending had to
-     out-shout the film instead of following it. So the phone spends the colour
-     by the line that names what the company does, and the last two beats are
-     already white. */
+  /* AND IT LANDS EARLIER ON A PHONE: the same window slid back to CLOSE where
+     it used to open. In a small frame the colour and the depth blur are the
+     loudest things present, and carrying them to the final mark made the ending
+     out-shout the film instead of following it. The phone spends the colour by
+     PRICE and the last two beats are already white. */
   const RES_SPAN = C.TO - 4 / 6;
   const resolveAt = (g) => {
     const a = phone ? 4 / 6 - RES_SPAN : RES_A;
     const b = phone ? 4 / 6 : RES_B;
     const u = clamp((g - a) / (b - a));
-    /* Two curves, because the two windows want opposite things. The wide
-       frame's is an ease-OUT: it leaves at speed and coasts into the close.
-
-       The phone's runs the other way — ease IN, the same exponent mirrored.
-       Its window is short and lands two beats early, and an ease-out spends
-       the colour in the first third of it, so the drain was over before the
-       reader had scrolled through the beat it belongs to. Easing in holds the
-       warm most of the way and then goes, which is a film ending rather than
-       a light being switched off. */
+    /* Opposite curves for opposite windows. Wide is an ease-OUT: it leaves at
+       speed and coasts into the close. The phone's is ease IN, the same
+       exponent mirrored — its window lands two beats early, and an ease-out
+       spent the colour before the reader had scrolled the beat it belongs to. */
     return phone ? Math.pow(u, RES_K)
                  : 1 - Math.pow(1 - u, RES_K);
   };
@@ -199,12 +151,9 @@
     return 'rgb(' + c(0) + ',' + c(1) + ',' + c(2) + ')';
   };
 
-  /* Both preferences are live, not read once at load. Reduced motion in
-     particular is a system-wide switch people flip while a page is open —
-     often BECAUSE a page is moving — and a preference that only takes effect
-     on the next reload is not much of a preference. The query objects are kept
-     so they can be listened to; see the listeners further down, which sit
-     below frame(). */
+  /* Both preferences are live, not read once: reduced motion is a system-wide
+     switch people flip while a page is open, often BECAUSE it is moving. The
+     query objects are kept so the listeners below frame() can attach. */
   const mqReduce  = matchMedia('(prefers-reduced-motion: reduce)');
   const mqPointer = matchMedia('(hover: hover) and (pointer: fine)');
   let reduce = mqReduce.matches;
@@ -215,9 +164,8 @@
   const finC   = document.getElementById('finC');
   const cta    = document.getElementById('cta');
   const counter = document.getElementById('bn');
-  /* The denominator was the last number on the page still written by hand,
-     which meant adding a beat to the argument left the chrome quietly
-     miscounting it. Same source as everything else now: the sections. */
+  /* The denominator was the last hand-written number on the page, so adding a
+     beat left the chrome miscounting. Same source as everything else now. */
   const total = document.getElementById('bt');
   if (total) total.textContent = String(S.length).padStart(2, '0');
 
@@ -229,13 +177,13 @@
   };
 
   const blocks = S.map(s => {
-    /* The finale lives outside .copy, which is anchored to the bottom margin.
-       It needs the whole viewport to travel through, so it gets its own. */
+    /* The finale lives outside .copy, which is anchored to the bottom margin:
+       it needs the whole viewport to travel through. */
     if (s.finale) {
       const [name, verb, claim] = s.lines;
       const l1 = line('l1', name), l2 = line('l2', verb), l3 = line('l3', '');
-      /* The claim is the one line with structure: the words, then the caret,
-         which is out of the centring by construction (see .l3 in the page). */
+      /* The claim is the one line with structure: words, then the caret, which
+         is out of the centring by construction (see .l3 in the page). */
       const tw = document.createElement('span'); tw.className = 't'; tw.textContent = claim;
       const cur = document.createElement('i'); cur.className = 'cur';
       l3.append(tw, cur);
@@ -256,10 +204,9 @@
   });
 
   /* ---- kinetic type ------------------------------------------------------
-     Resolve, then disintegrate — never travel. --sw is the sweep, which gives
-     the reveal a direction; --mk is the mark size, which is the reveal itself.
-     The sweep runs slightly ahead of the marks so the letterforms condense in
-     behind it rather than switching on with it. */
+     Resolve, then disintegrate — never travel. --mk is the mark size, which is
+     the reveal itself; --sw is a sweep giving it direction, run slightly ahead
+     so the letterforms condense in behind it rather than switch on with it. */
   const MK = 12;
   function paint(el, res, sw) {
     if (!el) return;
@@ -269,10 +216,9 @@
   function drive(el, t, delay, resolved, win) {
     if (!el) return;
     const [inAt, inLen] = win.in, [outAt, outLen] = win.out;
-    /* `resolved` skips the entrance. The first section is the page's opening
-       frame — the reader has not scrolled, so there is no gesture to respond
-       to, and a reveal there just means the page loads with no words on it.
-       It still disintegrates on the way out like every other section. */
+    /* `resolved` skips the entrance: section one is the opening frame, the
+       reader has not scrolled, and a reveal there just means the page loads
+       with no words on it. It still disintegrates on the way out. */
     const inA  = resolved ? 1 : outCubic(clamp((t - delay - inAt) / inLen));
     const sw   = resolved ? 1 : outCubic(clamp((t - delay) / (inLen + 0.04)));
     const outA = inQuad(clamp((t - outAt - delay * 0.5) / outLen));
@@ -281,138 +227,106 @@
 
   /* ---- the finale's choreography ----------------------------------------
      PIN is where the claim comes to rest, as a fraction of viewport height:
-     clear of the mark at the moment it lands, and it does not move again as
-     the mark keeps closing above it. GO is when the name and the verb stop
-     riding with it and leave. */
+     clear of the mark when it lands, and it does not move again as the mark
+     keeps closing above it. GO is when the name and verb stop riding with it. */
   const FIN = {
     PIN:   0.586,
     CLEAR: 0.034,         // gap held below the mark's lower edge
     GAP:   1.10,          // the lockup's own internal gap, in rem
-    /* The pair does not travel to the top of the frame and dissolve there. It
-       lifts a little and goes, low, while it is still under the mark — a long
-       climb left a ghost of the name legible at the very top of the page for
-       most of the section, which reads as a leftover rather than an exit.
-       LIFT is small on purpose; the fade does the work, the movement inflects
-       it. */
+    /* The pair lifts a little and goes, low, still under the mark. Climbing to
+       the top of the frame left a ghost of the name legible up there for most
+       of the section, reading as a leftover. LIFT is small: the fade works. */
     GO: 0.28, GO_LEN: 0.14, LIFT: 0.05,
     /* in / out windows per line: [start, length]. The claim never leaves. */
     IN:  [[0.00, 0.17], [0.045, 0.17], [0.095, 0.19]],
     OUT: [[0.28, 0.12], [0.30, 0.12]],
     /* The button waits for the film to be over. The mark stops closing at
-       g = 0.965, which is t = 0.79 of this section, and the claim stops being
-       pushed at the same instant — so that is the first moment there is a
-       still frame to arrive into.
+       g = 0.965 (t = 0.786 here, measured) and the claim stops being pushed at
+       the same instant — the first moment there is a still frame to arrive
+       into. Then a BEAT: starting at 0.79 exactly made the claim's stop and the
+       button's entrance one event, and neither read. The wait is now 0.473 of a
+       section, near a whole screen of scroll in which nothing happens, and only
+       once that has registered as an ending does the one action surface.
 
-       What was missing at first was the BEAT afterwards: the button used to
-       start arriving at 0.79 exactly, so the claim's stop and the button's
-       entrance were the same event and neither read. Measured, the claim goes
-       still at t = 0.786; the wait after it is now 0.473 of a section — 780px
-       at a 900px frame, near enough a whole screen of scroll — in which the
-       film has hit its wall and nothing whatsoever happens. That is the beat:
-       the reader keeps scrolling, the page does not move, and only once that
-       has plainly registered as an ending does the one action surface.
-
-       This is why TAIL exists. A wait that long puts the start well past
-       t = 1: there was not enough scroll left in the film to hold the pause
-       AND let the button surface, so the page carries most of a frame of
-       scroll the film does not use, and the button arrives on it. In the same
-       units as t the tail runs to 1.387, so the button is fully in at 1.354
-       with about 55px of scroll to spare underneath it. */
+       This is why TAIL exists: a wait that long starts well past t = 1. In t's
+       own units the tail runs to 1.387, so the button is fully in at 1.354 with
+       about 55px of scroll to spare underneath it. */
     CTA: [1.259, 0.095],
     CTA_RISE: 0.042,      // how far it floats up, as a fraction of the frame
     CTA_GAP: 1.4,         // below the claim, in rem, capped against short frames
-    /* How long the defocus dome takes to arrive under the lockup, in the same
-       units. It is fully there before the claim is — the claim's own window
-       opens at 0.095 — so the words land on a ground rather than watching one
-       appear behind them. Only the phone reads it; see .veil in the page. */
+    /* How long the defocus dome takes to arrive under the lockup, same units.
+       Fully there before the claim is (its window opens at 0.095), so the words
+       land on a ground. Only the phone reads it; see .veil in the page. */
     DOME: 0.14,
   };
   const easeIn = u => u * u;             // accelerates out of frame
 
   let ha = 0, gap = 0, ctaGap = 0;
-  /* Whether the copy is inside the mark or under it. The page does not own the
-     breakpoint — the stylesheet does, next to the rule that actually moves the
-     copy — so this reads the answer rather than restating the query. */
+  /* Copy inside the mark, or under it. The stylesheet owns the breakpoint, next
+     to the rule that moves the copy, so this reads the answer not the query. */
   let phone = false;
   const measure = () => {
     palette();
     phone = getComputedStyle(document.documentElement)
               .getPropertyValue('--phone').trim() === '1';
-    /* The CSS default is 1 and .cta carries a transition, so on first entering
-       the finale the link rendered at FULL opacity and faded back out over
-       ~120ms — giving away, 2.15 viewport-heights early, the exact thing TAIL
-       exists to withhold. Its opacity is entirely JS-driven; start it where it
-       belongs. */
+    /* The link's opacity is entirely JS-driven, and the CSS default is 1: on
+       first entering the finale it rendered fully lit, giving away 2.15
+       viewport-heights early the exact thing TAIL exists to withhold. */
     if (cta && !cta.style.opacity) cta.style.opacity = '0';
     const rem = parseFloat(getComputedStyle(document.documentElement).fontSize);
     ha  = finA.offsetHeight;
     gap = FIN.GAP * rem;
     /* Capped against the viewport as well as set in rem: on a landscape phone
-       a fixed 1.4rem below the claim is a large share of the whole frame, so
-       it also cannot exceed 3.75% of the height — the button has to fit under
-       the claim without the pair being crushed. */
+       1.4rem is a large share of the whole frame. */
     ctaGap = Math.min(FIN.CTA_GAP * rem, innerHeight * 0.0375);
     seatCopy();
   };
 
   /* THE COPY SITS IN THE CLEARING, NOT ON ITS FLOOR.
      ------------------------------------------------------------------------
-     The blocks were bottom-anchored, which aligns them by the bottom of
-     whatever each one happens to contain — an edge nobody can see. A two-line
-     headline and a three-line one with a sub-line under it put their words
-     107px apart down the frame at 1600x960, and the beat with the most in it
-     read as placed while the rest read as slipped.
+     Bottom-anchoring aligns blocks by the bottom of whatever each contains — an
+     edge nobody can see. At 1600x960 that put two beats' words 107px apart down
+     the frame, and the fullest beat read as placed while the rest slipped.
 
-     The film already answers where they belong. The shader clears a band at
-     the bottom of the frame FOR this copy — that is what FLOOR is — and the
-     copy's place is the middle of it, not its floor. So the space is measured
-     off the same four numbers the shader is given: its far edge is where the
-     band's taper is half applied, `-(centre + half-height + falloff/2)` in the
-     shader's own units, which is the line where the picture visibly gives way.
-     Everything below that down to .copy's own bottom margin is the clearing,
-     and every block is centred in it, so they all share a centre rather than
-     an invisible baseline.
+     The film already answers where they belong: the shader clears a band at the
+     bottom of the frame FOR this copy (that is FLOOR), and the copy's place is
+     the middle of it, not its floor. So the clearing is measured off the same
+     four numbers the shader is given — its far edge is where the band's taper
+     is half applied, `-(centre + half-height + falloff/2)` in the shader's own
+     units, the line where the picture visibly gives way — and every block is
+     centred in it, so they share a centre rather than an invisible baseline.
 
-     Whole block, not just the headline: the one beat with a sub-line reads as
-     one object, and hanging it off a shared headline centre puts more ink below
-     the line than above on that beat alone.
+     Whole block, not just the headline: the beat with a sub-line reads as one
+     object, and a shared headline centre puts more ink below the line than
+     above on that beat alone.
 
-     Phones are not in this. The copy is centred in the frame there by the
-     stylesheet, against a band that is not FLOOR until the ending, so this
-     hands the elements back and returns. */
+     Phones are not in this — the stylesheet centres the copy in the frame
+     there, against a band that is not FLOOR until the ending. */
   const seatCopy = () => {
     const heads = blocks.filter(b => b.head);
     for (const b of heads) { b.el.style.top = ''; b.el.style.bottom = ''; }
     if (phone) return;
     const H = innerHeight;
-    /* .copy is inset from the top, and .blk is positioned inside it, so the
-       clearing has to come back out of viewport coordinates to be usable. */
+    /* .copy is inset from the top and .blk sits inside it, so the clearing has
+       to come back out of viewport coordinates to be usable. */
     const inset = copy.getBoundingClientRect().top;
-    /* H, not fieldBase(H). The shader divides back out to the real height —
-       `sy = uv.y * base / uRes.y` — precisely so the band is the same share of
-       what the reader can see on a short viewport. Scaling by base instead
-       agrees only when the frame is 16:9 or taller, and on anything wider put
-       this line below the band it is meant to name. */
+    /* H, not fieldBase(H): the shader divides back out to the real height
+       (`sy = uv.y * base / uRes.y`) so the band is the same share of what the
+       reader sees. Scaling by base agrees only at 16:9 or taller. */
     const from  = H * (0.5 + CLEARING) - inset;
-    /* To the frame's own bottom edge, not to .copy's bottom margin. The shader
-       clears the band all the way down — it cannot clear past the frame — and
-       that margin is a layout inset with no claim on where the picture ends.
-       Measuring to it pulled the centre up by half of it, 0.029H, which is
-       exactly what read as high. */
+    /* To the frame's own bottom edge, not .copy's bottom margin: the shader
+       clears the band all the way down, and that margin is a layout inset with
+       no claim on where the picture ends. Measuring to it pulled the centre up
+       0.029H, which is what read as high. */
     const to    = H - inset;
-    /* The margin is still a floor. On a short window the clearing is shorter
-       than the deepest beat and its centre would push that beat past the
-       bottom of the frame — so the floor is applied ONCE, to the tallest
-       block, and every beat rises with it. Clamping each block on its own
-       would let the short beats keep the low centre while the tall ones stop
-       above it, which is the spread this exists to remove: measured 55px at
-       1600x960 and 65px at 1280x800 before it was hoisted out of the loop. */
+    /* The margin is still a floor, applied ONCE to the tallest block so every
+       beat rises with it. Clamping each block on its own leaves the short beats
+       at the low centre while the tall ones stop above it — the spread this
+       exists to remove (55px at 1600x960, 65px at 1280x800). */
     const tall  = Math.max(...heads.map(b => b.el.offsetHeight));
-    /* DROP is by eye, and it is applied AFTER the floor rather than to the
-       clearing's centre, because on every frame shorter than about 1150px the
-       floor is what is binding and an offset above it would be swallowed.
-       So it lowers both: the seat where the clearing sets it, and the floor
-       where the deepest beat does. */
+    /* DROP is by eye, and applied AFTER the floor rather than to the clearing's
+       centre: below about 1150px tall the floor is what binds, and an offset
+       above it would be swallowed. This lowers both seats. */
     const rem   = parseFloat(getComputedStyle(document.documentElement).fontSize);
     const seat  = Math.min((from + to) / 2, copy.clientHeight - tall / 2) + DROP * rem;
     for (const b of heads) {
@@ -421,56 +335,45 @@
     }
   };
   /* The faces are font-display:block, so the first measure can land on fallback
-     metrics and seat the blocks by a height that is about to change. Nothing
-     else here was that sensitive to it — the old bottom anchor did not care what
-     a block measured — so this re-seats them alone rather than forcing a whole
-     remeasure. */
+     metrics and seat the blocks by a height about to change. Nothing else is
+     that sensitive, so this re-seats alone rather than forcing a remeasure. */
   if (document.fonts && document.fonts.ready) document.fonts.ready.then(seatCopy);
 
   /* The shader's own normalisation, in JS. baseOf() in ptl-field.js is the
-     original; this is the only other copy and both are written from CLOSE, so
-     a retune moves them together. */
+     original; both are written from CLOSE, so a retune moves them together. */
   const fieldBase = H => Math.max(H, innerWidth / C.ASPECT);
   /* On a phone the mark sits on the frame's centre rather than above it, and
-     this file has to agree with the shader about that or the closing lockup is
-     placed against a mark that is not where it thinks. */
+     this file must agree with the shader or the closing lockup is placed
+     against a mark that is not where it thinks. */
   const lift = () => (phone ? 0 : 1);
 
   /* WHERE THE COPY IS, for the shader to keep clear of — (centre, half-height,
-     half-width, falloff), the first two as a fraction of the frame's height
-     and the third in the shader's own uv, which is normalised on `base`.
+     half-width, falloff), the first two as a fraction of the frame's height and
+     the third in the shader's own uv, normalised on `base`. FLOOR is the bottom
+     of a landscape frame in those terms: a band centred below the bottom edge
+     whose taper reaches zero 9% under the middle, which every wide viewport
+     gets for the whole film.
 
-     FLOOR is the bottom of a landscape frame written in those terms: a band
-     centred below the bottom edge whose taper reaches zero 9% under the
-     middle. Every wide viewport gets it for the whole film, and it draws what
-     the three constants in the shader used to draw, to the pixel.
-
-     A phone gets a band of negative height instead — nothing cleared at all. The copy there is not
-     under the mark, it is inside it, sitting in the ring's own void; clearing
-     a band as well took out the lower arc and the lattice beneath it and left
-     the film 190px short of the bottom edge. Parting the form around the words
-     instead was tried and reverted: on a frame this narrow the words are as
-     big as the circle, so the hole ate the ring's shoulders and what was left
-     read as an egg. The words simply sit on the picture, where the picture is
-     already black.
+     A phone gets a band of negative height — nothing cleared. The copy there is
+     not under the mark but inside it, in the ring's own void; clearing a band
+     as well took out the lower arc and the lattice beneath it and left the film
+     190px short of the bottom edge. Parting the form around the words was tried
+     and reverted: at that width the words are as big as the circle, so the hole
+     ate the ring's shoulders and what was left read as an egg.
 
      The ending is the exception at both sizes: the lockup IS on the floor, so
-     as it arrives the phone's band grows out of the bottom edge to FLOOR's, on
-     the same ramp that brings the dome up. */
+     the phone's band grows out of the bottom edge to FLOOR's, on the same ramp
+     that brings the dome up. */
   const FLOOR = [-0.40, 0.10, 0.40, 0.21];
   /* Where the band's taper is half applied: the line, in the shader's own
-     units, at which the picture visibly gives way to the copy's ground. Read
-     by seatCopy above, which runs long after this. */
+     units, at which the picture gives way to the copy's ground. */
   const CLEARING = -(FLOOR[0] + FLOOR[1] + FLOOR[3] / 2);
-  /* And a rem below that, which is not derived from anything — it was asked
-     for against the rendered frame. */
+  /* And a rem below that — not derived, asked for against the rendered frame. */
   const DROP = 1;
 
-  /* The mark's lower edge in screen px — the same arithmetic as form()'s
-     radius track, restricted to the last section, where every track but the
-     closing one has already reached its end value.
-
-     The constants are C's, above — the field's, not this file's. */
+  /* The mark's lower edge in screen px: form()'s radius track, restricted to
+     the last section where every track but the closing one is at its end value.
+     The constants are C's — the field's, not this file's. */
   function markBottom(g, H) {
     const base = fieldBase(H);
     const r = C.R - C.DR * smooth(C.FROM, C.TO, g);
@@ -478,23 +381,18 @@
   }
 
   function finale(b, t, H, ct) {
-    /* The claim does not follow a timed curve into the pin — it is HELD DOWN
-       by the mark and released as the mark closes. A timed curve put it
-       straight through the middle of the ring on the way up, which is
-       unreadable and also a lie about what is happening: the words rise
-       because the form is getting out of their way. Once the mark has closed
-       past the pin, the constraint stops binding and the claim is pinned. */
+    /* The claim is HELD DOWN by the mark and released as the mark closes, not
+       driven by a timed curve — that put it straight through the middle of the
+       ring, which is unreadable and also a lie: the words rise because the form
+       is getting out of their way. Past the pin the constraint stops binding. */
     const g    = (S.length - 1 + t) / S.length;
     const rise = lerp(H * 1.16, H * 0.50, clamp(t / 0.30));   // the entrance only
-    /* …but never so low that the claim runs off the bottom. On a landscape
-       phone with the URL bar showing, markBottom is driven by `base` (the
-       WIDTH there) while the pin is a share of the height, and the two
-       disagreed enough to slice the closing line in half. */
-    /* What has to fit BELOW the claim. Reserved statically, not as the button
-       fades in: growing the reservation on arrival would drag the claim upward
-       at the exact moment the frame is supposed to be still. On any ordinary
-       viewport this never binds — the pin sits far above the clamp — so it
-       costs nothing except on the short frames it exists for. */
+    /* …but never so low that the claim runs off the bottom: on a landscape
+       phone markBottom is driven by `base` (the WIDTH there) while the pin is a
+       share of the height, and the two disagreed enough to slice the line.
+       `tail` is what must fit BELOW the claim, reserved statically rather than
+       as the button fades in — growing it on arrival would drag the claim
+       upward at the moment the frame is meant to be still. */
     const tail = finC.offsetHeight + ctaGap;
     const bY   = Math.min(
       Math.max(rise, H * FIN.PIN, markBottom(g, H) + H * FIN.CLEAR),
@@ -507,12 +405,10 @@
       `translate(-50%,${(bY + finB.offsetHeight + ctaGap).toFixed(1)}px)`;
 
     if (reduce) {
-      /* Static, fully readable, clear of the closing mark — and the button is
-         simply present rather than arriving, since its arrival is the motion. */
-      /* The same floor the animated branch enforces. Without it this branch
-         never read markBottom at all and set the name line 26px inside the
-         closed ring (71px in landscape), printing serif type onto the mark's
-         own dots. */
+      /* Static, fully readable, clear of the closing mark — the same floor the
+         animated branch enforces. Without it this branch never read markBottom
+         and set the name line 26px inside the closed ring (71px landscape),
+         printing serif type onto the mark's own dots. */
       const rY = Math.min(
         Math.max(H * 0.70 - tail * 0.5,
                  markBottom(1, H) + H * FIN.CLEAR + gap + ha),
@@ -526,18 +422,15 @@
       cta.style.opacity = '1';
       cta.style.transform = 'none';
       cta.style.pointerEvents = 'auto';
-      /* AND IT HAS TO BE LIVE. inert is set in exactly one place — floatCta,
-         which this branch returns before reaching — so a reader who scrolls
-         into the finale with motion on (inert true, the link not yet faded up)
-         and THEN turns reduce on was handed a button at full opacity, with
-         pointer-events auto, that could not be clicked, tapped or focused:
-         inert had nothing left to clear it. The page's only action, dead,
-         under the one preference that most needs it to be simple.
+      /* AND IT HAS TO BE LIVE. inert is set only in floatCta, which this branch
+         returns before reaching — so a reader who scrolled into the finale with
+         motion on and THEN turned reduce on was handed a full-opacity button,
+         pointer-events auto, that could not be clicked, tapped or focused.
 
-         ctaU and ctaSettling go with it. Leaving ctaSettling true strands
+         ctaU and ctaSettling go with it: leaving ctaSettling true strands
          tick()'s `arriving` re-arm permanently high — an unbounded rAF running
-         two full-screen GL passes a frame on the last screen, under the exact
-         preference the still-frame exists to honour. */
+         two fullscreen GL passes a frame, under the exact preference the still
+         frame exists to honour. */
       cta.inert = false;
       ctaU = 1;
       ctaSettling = false;
@@ -552,46 +445,39 @@
     floatCta(ct, H);
   }
 
-  /* The button's own arrival, which is not fadeLine's. The lockup's lines come
-     in through a mask wipe because they are type resolving out of the field;
-     the button is an object that appears once the argument is over, and a wipe
-     read as one more flourish on a frame that is supposed to have stopped
-     moving. Opacity and a rise, on a smoothstep so it is gentle at both ends
-     rather than launching and braking. */
+  /* The button's own arrival, which is not fadeLine's: the lockup's lines wipe
+     in because they are type resolving out of the field, while the button is an
+     object appearing once the argument is over, and a wipe read as one more
+     flourish on a frame supposed to have stopped. Opacity and a rise, on a
+     smoothstep so it is gentle at both ends. */
   let ctaU = 0, ctaSettling = false, ctaTs = 0;
   function floatCta(t, H) {
     if (!cta) return;
     const target = smooth(FIN.CTA[0], FIN.CTA[0] + FIN.CTA[1], t);
-    /* Rate-limited HERE rather than by a CSS transition. This function drives
-       the opacity and the rise from one number, but only opacity was
-       transitioned — so under a fling the transform snapped to its final value
-       while CSS was still easing the fade, and 0.0px of the 39px rise survived
-       to the frame where the link became half-visible. The arrival was not one
-       at any realistic swipe speed, and it ran backwards too. This guarantees
-       ~0.37s of rise-and-fade however hard the flick is, keeps both
-       properties on one clock, and settles deterministically both ways. */
-    /* Per second, not per frame — the same correction the ambient clock
-       above needed. Both rates were tuned against 60Hz, so they stay written
-       in 60ths and are scaled by the time actually elapsed; on a 120Hz screen
-       the arrival was running at double speed, which is the flourish the rate
-       limit exists to prevent. Clamped, because this is driven from the
-       scroll path as well, and a flick after a pause would otherwise hand it
-       the whole pause in one step. */
+    /* Rate-limited HERE rather than by a CSS transition. Opacity and rise come
+       from one number, but only opacity was transitioned — so under a fling the
+       transform snapped to its final value while CSS was still easing the fade,
+       and 0.0px of the 39px rise survived to the frame where the link became
+       half-visible. This keeps both on one clock and guarantees ~0.37s of
+       rise-and-fade however hard the flick is.
+
+       Per second, not per frame: the rates are tuned at 60Hz, so at 120Hz the
+       arrival ran at double speed — the flourish the limit exists to prevent.
+       Clamped, because this is driven from the scroll path too and a flick
+       after a pause would otherwise arrive in one step. */
     const now = performance.now();
     const k = ctaTs ? Math.min((now - ctaTs) / 1000, 0.05) * 60 : 1;
     ctaTs = now;
     ctaU = target < ctaU ? Math.max(target, ctaU - 0.09 * k)
                          : Math.min(target, ctaU + 0.06 * k);
-    /* One flag, set from the only place that knows. Deriving this at the call
-       site got it wrong twice: `ctaU > 0` is false on the very first frame of
-       an arrival, and the finale's `.on` class is not on the element this
-       file holds — so the loop shut down before the link had finished coming
-       in, and it stalled wherever the last frame left it (0.30, 0.72). */
+    /* One flag, set from the only place that knows. Derived at the call site it
+       was wrong twice: `ctaU > 0` is false on an arrival's first frame, and the
+       finale's `.on` class is not on the element this file holds — so the loop
+       shut down mid-arrival and the link stalled at 0.30, 0.72. */
     ctaSettling = ctaU !== target;
-    /* The arrival has to be able to finish on its own. Past CLOSE.TO the
-       ambient loop deliberately shuts down, so without this the link stalled
-       wherever the last scroll frame left it — the rate limit turned into a
-       permanent half-fade. */
+    /* The arrival has to finish on its own: past CLOSE.TO the ambient loop
+       deliberately shuts down, so without this the rate limit becomes a
+       permanent half-fade wherever the last scroll frame left it. */
     if (ctaU !== target) tick();
     const u = ctaU;
     cta.style.opacity = u.toFixed(3);
@@ -603,19 +489,17 @@
   }
 
   /* One line's arrival and departure: mask, opacity and a small travel of its
-     own, all on the same clock. The travel is per-line and additive to the
-     group's — it is what stops three simultaneous fades reading as one block
-     switching on. */
+     own, on one clock. The travel is per-line and additive to the group's —
+     it stops three simultaneous fades reading as one block switching on. */
   function fadeLine(el, inU, outU, H) {
     if (!el) return;
     el.style.setProperty('--rv', inU.toFixed(3));
     el.style.setProperty('--ex', outU.toFixed(3));
     const a = inU * (1 - outU);
     el.style.opacity = a.toFixed(3);
-    /* A faded line is still a box. Left hit-testing it would put an I-beam
-       over an empty band of the closing frame — the name and the verb leave
-       but their boxes do not — so the pointer is handed back only while there
-       is something legible to put a cursor in. */
+    /* A faded line is still a box: the name and verb leave but their boxes do
+       not, so hit-testing them puts an I-beam over an empty band of the closing
+       frame. The pointer comes back only while there is something legible. */
     el.style.pointerEvents = a > 0.05 ? 'auto' : 'none';
     el.style.transform =
       `translateY(${((1 - inU) * H * 0.030 - outU * H * 0.026).toFixed(1)}px)`;
@@ -623,46 +507,33 @@
 
   /* ---- the pointer -------------------------------------------------------
      Only the closing mark answers it, and only once it has closed. `tgt` is
-     where the pointer is, `cur` is where the light actually is; the light
-     chases at a fixed rate per frame so a flick of the wrist is a sweep rather
-     than a jump. Coordinates are converted into the shader's own uv space,
-     including its long-side normalisation, so the light direction means the
-     same thing at any aspect ratio.
-
-     Disabled outright under prefers-reduced-motion and on devices with no
-     hovering pointer, where there is nothing to answer and the mark should
-     simply be lit head-on. */
+     where the pointer is, `cur` where the light actually is; the light chases
+     at a fixed rate so a flick of the wrist is a sweep, not a jump. Coordinates
+     go into the shader's own uv space, long-side normalisation included, so a
+     direction means the same thing at any aspect ratio. Off outright under
+     reduced motion and with no hovering pointer, where the mark is lit
+     head-on. */
   let POINTER = !reduce && mqPointer.matches;
   const tgt = [0, 0], cur = [0, 0];
   const clampAxis = v => (v < -0.9 ? -0.9 : v > 0.9 ? 0.9 : v);
   let act = 0;
 
-  /* Registered unconditionally and gated inside, because POINTER can turn on
-     later — a tablet gains a mouse, or reduced motion is switched off — and a
-     listener that was never attached cannot be attached retroactively from the
-     media query's own handler without more bookkeeping than the check costs. */
+  /* The pointermove listener below is registered unconditionally and gated
+     inside, because POINTER can turn on later — a tablet gains a mouse, or
+     reduced motion goes off — and attaching retroactively costs more
+     bookkeeping than the check does. */
   /* THE CARET SLEEPS, AND IT HAS TO BE ABLE TO WAKE.
-     ------------------------------------------------------------------------
-     The blink is capped at twelve iterations, which is deliberate: a 2x22px
-     block toggling forever measured as 97% of the closing screen's remaining
-     power draw, on the one screen the reader is meant to sit on. What was
-     missing is the other half of that bargain. Twelve iterations is 12.7
-     seconds, after which the animation FINISHES and holds its base opacity —
-     which is 1 — so the caret ends as a solid lit block and stays that way
-     for the rest of the visit. Measured: last toggle at 10.91s, no animations
-     on the element at 17s. A reader who sits with the page for a quarter of a
-     minute is looking at a cursor that has stopped, and a cursor that has
-     stopped reads as broken rather than as finished.
+     The blink is capped at twelve iterations because a 2x22px block toggling
+     forever measured 97% of the closing screen's remaining power draw. But
+     twelve iterations is 12.7s, after which the animation FINISHES on its base
+     opacity of 1 — a solid lit block for the rest of the visit, which reads as
+     broken rather than as finished. So it sleeps only while nothing is
+     happening, and any sign of a reader starts it again.
 
-     So it sleeps only while nothing is happening, and any sign of a reader
-     starts it again. The getAnimations() check is what keeps this cheap: while
-     the blink is still running this returns early and costs nothing, and the
-     forced reflow — the only way to restart a CSS animation — happens at most
-     once per idle period rather than once per event.
-
-     Under reduced motion the stylesheet removes the animation outright, so
-     there is nothing to wake and trying would force a reflow on every mouse
-     move for no result. */
+     getAnimations() keeps this cheap: while the blink runs this returns early,
+     so the forced reflow — the only way to restart a CSS animation — happens
+     once per idle period, not once per event. Under reduced motion the
+     stylesheet removes the animation, so there is nothing to wake. */
   function wakeCaret() {
     if (reduce) return;
     const cur = blocks[blocks.length - 1] && blocks[blocks.length - 1].cur;
@@ -683,64 +554,45 @@
   }, { passive: true });
 
   /* ---- the ambient clock -------------------------------------------------
-     Scroll is no longer the ONLY clock. It is still the only thing that moves
-     the argument — every position, every beat, the whole composition remains a
-     pure function of scrollY, and that has not changed — but the field now
-     breathes on its own underneath it, so a page nobody is touching is alive
-     rather than a screenshot.
+     Scroll still moves the whole ARGUMENT; the field breathes underneath it so
+     a page nobody is touching is alive rather than a screenshot. The two are
+     deliberately different KINDS of clock: scroll drives structure and is exact
+     and reversible, this drives texture only — the size of the halftone marks,
+     nothing else — and is monotonic. Nothing that decides where a word sits
+     reads it, so at worst the halftone is a few frames further through a sine.
 
-     The two clocks are deliberately different KINDS of thing. Scroll drives
-     structure and is exact and reversible; this drives texture only (mark size,
-     nothing else — see the shader) and is monotonic. Nothing that decides where
-     a word sits reads it, which is why it cannot desynchronise anything: at
-     worst the halftone is a few frames further through a sine.
-
-     Scrolling makes it run faster. `vel` is scroll distance in viewport-heights
-     accumulated since the last frame and decayed continuously, so the rate
-     answers to how hard you are moving rather than to whether an event fired —
-     it stays lifted through a flick and settles back on its own. */
+     Scrolling makes it run faster: `vel` is scroll distance in viewport-heights
+     accumulated and decayed continuously, so the rate answers to how hard you
+     are moving rather than to whether an event fired. */
   const AMB_IDLE = 1.0;    // clock seconds per real second, untouched
   const AMB_GAIN = 5.5;    // extra, at full scroll speed
   const AMB_DECAY = 0.86;  // how fast the boost bleeds off, per 60th of a second
   let clock = 0, lastTs = 0, vel = 0, lastY = 0;
-  /* Ambient motion is motion, so prefers-reduced-motion turns it off outright
-     and the page goes back to being driven by scroll alone.
-
-     …and so does having nothing to move. The breathe reaches exactly one
-     thing, the size of the halftone marks, so with no renderer mounted — no
-     WebGL2, or ptl-field.js missing — the loop was holding the compositor
-     open at 60fps to advance a clock nothing reads and redraw type that only
-     scroll can move. That is the same waste `still` exists to stop, on the
-     machines least able to afford it. Scroll, the pointer and the link's
-     arrival all keep their own paths into the loop, so nothing that can still
-     move stops moving.
-
-     A field that died with its context is the same case, and so is one whose
-     context has merely GONE: draw() returns immediately for both, so the loop
-     would be spinning against a picture that cannot change. A lost context is
-     not always given back — a driver reset on a visible tab can sit there —
-     and this page is nothing but that context, so it is worth not burning a
-     core waiting. The restore listener below is what starts the clock again;
+  /* Ambient motion is motion, so reduced motion turns it off outright — and so
+     does having nothing to move. The breathe reaches exactly one thing, mark
+     size, so with no renderer mounted the loop held the compositor open at
+     60fps to advance a clock nothing reads. A dead context is the same case,
+     and so is a merely LOST one: draw() returns immediately for both, and a
+     lost context is not always given back. Scroll, the pointer and the link's
+     arrival keep their own paths in, so nothing that can still move stops
+     moving; the restore listener below is what starts the clock again, and
      without it this optimisation would be a freeze.
 
-     `field` is declared below, after the mount: this is only ever CALLED from
-     a frame, and the first frame is scheduled at the foot of the file. */
+     `field` is declared below, after the mount: this is only ever CALLED from a
+     frame, and the first frame is scheduled at the foot of the file. */
   const ambient = () => (reduce || !field || field.isDead() || field.isLost() ? 0 : 1);
 
-  /* One frame loop, for everything that is not scroll position: the ambient
-     clock and the pointer light easing toward the cursor. It runs continuously
-     while there is ambient motion to draw, and otherwise only while the light
-     is still settling — a page with reduced motion and no pointer holds the
-     compositor open exactly as little as it did before. */
+  /* One frame loop for everything that is not scroll position: the ambient
+     clock, and the pointer light easing toward the cursor. Continuous while
+     there is ambient motion to draw, otherwise only while the light settles. */
   let ticking = 0;
   function tick() {
     if (ticking) return;
     ticking = requestAnimationFrame(function step(ts) {
       ticking = 0;
       /* Clamped for the one enormous delta a backgrounded tab hands back, and
-         ONLY that: a gap past 0.5s is a returning tab, everything else is a
-         slow frame. Applied to every frame it dilated time on the devices
-         already struggling — at 15fps the ambient clock ran at 0.72 s/s. */
+         ONLY that: past 0.5s is a returning tab, everything else is a slow
+         frame. Applied to every frame it ran the clock at 0.72 s/s at 15fps. */
       const raw = lastTs ? (ts - lastTs) / 1000 : 0.016;
       const dt  = raw > 0.5 ? 0.016 : Math.min(raw, 0.25);
       lastTs = ts;
@@ -750,21 +602,18 @@
       }
       const dx = tgt[0] - cur[0], dy = tgt[1] - cur[1];
       /* The chase rate eases on distance too: near the mark the light is
-         attentive, far from it the light is lazy. Same idea as the shader's
-         amplitude falloff, on the time axis instead of the space one — moving
-         about the far edges of the page should not whip the terminator. */
+         attentive, far from it lazy — the shader's amplitude falloff on the
+         time axis. Roaming the far edges should not whip the terminator. */
       const dist = Math.hypot(tgt[0], tgt[1] - 0.02);
       const rate = 0.036 + 0.048 * (1 - Math.min(dist / 0.9, 1));
       cur[0] += dx * rate;
       cur[1] += dy * rate;
       render();
       const settling = act > 0.001 && (Math.abs(dx) > 0.0004 || Math.abs(dy) > 0.0004);
-      /* document.hidden: a hidden tab gets no frames anyway in every current
-         browser, but asking for them is still a promise to burn a core if one
-         ever obliges. */
-      /* ctaU is rate-limited, so it can still be travelling after scroll has
-         stopped: a flick ending mid-band would otherwise strand the link
-         half-faded forever. */
+      /* document.hidden: a hidden tab gets no frames anyway, but asking for
+         them is a promise to burn a core if one ever obliges. And ctaU is
+         rate-limited, so it can still be travelling after scroll has stopped —
+         a flick ending mid-band would otherwise strand the link half-faded. */
       const arriving = ctaSettling;
       if ((ambient() && !still && !document.hidden) || settling || arriving) tick();
     });
@@ -779,29 +628,23 @@
 
   /* ---- the frame ---------------------------------------------------------
      `typeof`, not truthiness: on a failed load PTLField is an undeclared name,
-     so `PTLField && …` throws a ReferenceError rather than short-circuiting.
-     It threw here, after the body had already been stretched to the film's
-     full height — leaving the fallback as one screen of words at the top of a
-     very long empty page. Nothing is committed to until the mount is done. */
+     so `PTLField && …` throws rather than short-circuiting. It threw here,
+     after the body had been stretched to the film's full height — one screen of
+     words atop a very long empty page. Nothing is committed until the mount. */
   const field = typeof PTLField !== 'undefined'
     ? PTLField.mount(document.getElementById('c'), { mode: 'form' })
     : null;
-  /* A null field is not a failure worth falling back over: it means WebGL2 is
-     unavailable (or the script is missing), and the choreographed type carries
-     the whole argument on its own against a plain ground. What the fallback
-     document exists for is the case where none of THIS runs. */
-  /* A restored context rebuilds the program but nothing asks it to draw, and
-     under reduced motion the ambient loop has already self-terminated — so
-     the film simply vanished until the reader happened to scroll. A LOST
-     context is the mirror: the last frame freezes and reads as truth. Both
-     directions want exactly one frame.
-
-     The restore wants the CLOCK back as well, not just a frame. ambient() is
-     0 for the whole of a loss, so by the time the context returns the loop
-     has long since self-terminated and one redraw would hand the reader a
-     correct, permanently still picture. tick() is safe on the other side of
-     that too: if the rebuild failed, the field is dead, ambient() is still 0
-     and the step shuts down again after the single frame it owes. */
+  /* A null field is not a failure worth falling back over: WebGL2 is
+     unavailable, and the choreographed type carries the whole argument against
+     a plain ground. The fallback document is for when none of THIS runs. */
+  /* A restored context rebuilds the program but nothing asks it to draw, so the
+     film vanished until the reader happened to scroll; a LOST context is the
+     mirror, freezing a last frame that reads as truth. Both want exactly one
+     frame. The restore wants the CLOCK back too — ambient() is 0 for the whole
+     of a loss, so the loop has long since self-terminated and one redraw would
+     leave a correct, permanently still picture. tick() is safe either way: if
+     the rebuild failed the field is dead, ambient() is still 0, and the step
+     shuts down after the single frame it owes. */
   {
     const cv = document.getElementById('c');
     if (field && cv) {
@@ -817,36 +660,31 @@
   let endU = -1;                          // last published --ending
   let resU = '';                          // last published --resolved
   /* True once the film has finished closing. Past PTLField.CLOSE.TO the
-     fragment program is a pure function of constants — the ambient term is
-     multiplied by (1 - smoothstep(0.86, 0.965, g)), exactly zero there, and
-     the pointer light never runs on a phone. Verified by hashing the drawing
-     buffer: 124 consecutive draws, ONE distinct buffer. So the last 1.1
-     viewport-heights were 60 identical fullscreen shader passes a second,
-     forever, on the screen the reader is meant to sit still on — 82% of that
-     frame's power draw, provably wasted. Keyed to the shader's own constant
-     so the two cannot drift. */
+     fragment program is a pure function of constants — hashing the drawing
+     buffer, 124 consecutive draws gave ONE distinct buffer — so the last 1.1
+     viewport-heights were 60 identical fullscreen passes a second, forever, on
+     the screen the reader is meant to sit still on: 82% of that frame's power
+     draw. Keyed to the shader's own constant so the two cannot drift. */
   let still = false;
 
   function render() {
     const max  = document.documentElement.scrollHeight - innerHeight;
-    /* The film's own scroll, which is the document minus the tail. Everything
-       the film does is a function of THIS, so the tail cannot stretch a single
-       cue: past `film`, p is pinned at 1 and every track is already at its end
-       value. */
+    /* The film's own scroll: the document minus the tail. Everything the film
+       does is a function of THIS, so the tail cannot stretch a cue — past
+       `film`, p is pinned at 1 and every track is at its end value. */
     const film = filmLen();
     /* Clamped, because scrollY is not bounded by the document: Safari's elastic
-       overscroll reports negative at the top and past `max` at the bottom, and
-       an unclamped p drove the section index to -1, where blocks[-1] is
-       undefined and this function threw on every frame of the bounce. */
+       overscroll reports negative at the top, and an unclamped p drove the
+       section index to -1, where blocks[-1] is undefined and this threw every
+       frame of the bounce. */
     const p    = clamp(window.scrollY / film);
     const span = 1 / S.length;
     still = p >= C.TO;
     const idx  = Math.min(S.length - 1, Math.floor(p / span));
     const t    = (p - idx * span) / span;
-    /* The button's clock: t while the film is running, and then t past 1,
-       measured in the same units, through the tail. Nothing else reads it — the
-       whole point is that the frame is held while this one number keeps
-       moving. */
+    /* The button's clock: t while the film runs, then t past 1 in the same
+       units, through the tail. Nothing else reads it — the whole point is that
+       the frame is held while this one number keeps moving. */
     const tailU = clamp((window.scrollY - film) / Math.max(max - film, 1));
     const ct    = t + tailU * (TAIL * S.length / (S.length * PER - 1));
 
@@ -860,7 +698,7 @@
       finale(b, t, innerHeight, ct);
     } else if (reduce) {
       /* Reduced motion: fully resolved, no sweep. The argument IS the page, so
-         it has to be completely readable with every animation disabled. */
+         it must be completely readable with every animation disabled. */
       for (const el of [b.head, b.body]) {
         if (!el) continue;
         el.style.setProperty('--mk', MK + 'px');
@@ -872,23 +710,20 @@
       drive(b.body, t, 0.06, open, S[idx].win);   // body resolves just behind its headline
     }
 
-    /* The mark only answers the pointer once it has actually closed — before
-       that it is still a ring with a lattice around it, and lighting that
-       would be lighting a diagram. */
+    /* The mark answers the pointer only once it has closed: before that it is a
+       ring with a lattice around it, and lighting that is lighting a diagram. */
     act = POINTER ? smooth(0.88, 0.955, p) : 0;
 
-    /* The writing resolves with the picture. Set on the root so every rule
-       that reads --ink-live moves at once — the claim, the lockup, the caret
-       and the CTA — rather than each being animated on its own timetable and
-       drifting apart. Under reduce the film is held at its end, so the type is
-       held at its end too. */
+    /* The writing resolves with the picture. Set on the root so every rule that
+       reads --ink-live moves at once — claim, lockup, caret, CTA — rather than
+       each drifting on its own timetable. Under reduce the film is held at its
+       end, so the type is held there too. */
     const res = resolveAt(reduce ? 1 : p);
     document.documentElement.style.setProperty('--ink-live', mixHex(TYPE_A, TYPE_B, res));
-    /* The same number, unmixed, for the rules that need the CURVE rather than
-       a colour off it — .deep, whose blur is part of the film and has to leave
-       on the film's clock rather than a second one of its own. Written only
-       when it changes, like --ending below: it is pinned at 0 for the first
-       three beats and at 1 for the last two, and every write invalidates
+    /* The same number unmixed, for rules that need the CURVE rather than a
+       colour off it — .deep, whose blur is part of the film and has to leave on
+       the film's clock. Written only when it changes, like --ending: it is
+       pinned at 0 for three beats and 1 for two, and every write invalidates
        style for a rule that blurs the whole frame. */
     const resS = res.toFixed(3);
     if (resS !== resU) {
@@ -897,12 +732,11 @@
     }
 
     /* How far into the ending we are, published rather than applied: the
-       stylesheet decides who wants it. On a phone the defocus dome is only for
-       the finale, which is the one section whose copy is on the floor; on a
-       wide frame the dome is unconditional and nothing reads this. A pure
-       function of scroll like every other cue, so scrubbing back up takes the
-       dome away again rather than leaving it on a timer. Written only when it
-       changes — it is 0 for five sixths of the page. */
+       stylesheet decides who wants it. On a phone the dome is only for the
+       finale, the one section whose copy is on the floor; on a wide frame it is
+       unconditional and nothing reads this. A pure function of scroll, so
+       scrubbing back up takes the dome away rather than leaving it on a timer.
+       Written only when it changes — 0 for five sixths of the page. */
     const end = b.fin ? (reduce ? 1 : outCubic(clamp(t / FIN.DOME))) : 0;
     if (end !== endU) {
       endU = end;
@@ -913,28 +747,25 @@
        draw() would return immediately anyway, but there is no reason to build
        it an options object sixty times a second to be ignored. */
     if (field && !field.isDead()) field.draw(t, {
-      /* Under reduce the mark is HELD CLOSED. It was still morphing with
-         scroll — only the ambient clock was disabled — and the closing ring's
-         bright arc swept up through a lockup that reduce pins in place, which
-         put 86% of the verb's ink under 4.5:1. */
+      /* Under reduce the mark is HELD CLOSED. It was still morphing with scroll
+         — only the ambient clock was disabled — and the closing ring's bright
+         arc swept up through a lockup reduce pins in place, putting 86% of the
+         verb's ink under 4.5:1. */
       g: reduce ? 1 : p, section: idx, word: S[idx].key,
       /* The keep-out band is for copy on the floor. On a phone there is none
          until the ending, so it OPENS on the ending's own ramp and the film
          gets the whole frame back for the argument itself.
 
-         Only the half-height moves. Lerping the whole box from somewhere
-         off-frame was tried and it does not travel at all: the band is a
-         hundredth of a frame tall against a centre nine frames down, so it
-         stays outside the picture until the centre has almost arrived and
-         then snaps in over the last 4.5% of the ramp. Measured — nothing is
-         cleared until end = 0.955. Fixing the centre where it belongs and
-         growing the band out of the bottom edge is the same end state and an
-         actual opening.
+         Only the half-height moves. Lerping the whole box in from off-frame
+         does not travel at all: the band is a hundredth of a frame tall against
+         a centre nine frames down, so nothing is cleared until end = 0.955
+         (measured) and then it snaps in. Growing the band out of the bottom
+         edge instead is the same end state and an actual opening.
 
-         It starts at MINUS the falloff so that at end 0 the taper cannot
-         reach the frame either: smoothstep(-w, 0, |x|) is 1 for every |x|, so
-         the band is exactly zero. Starting at 0 instead would leave 64% of it
-         standing at the frame's floor before the ending had begun. */
+         It starts at MINUS the falloff so that at end 0 the taper cannot reach
+         the frame either: smoothstep(-w, 0, |x|) is 1 for every |x|, so the
+         band is exactly zero. Starting at 0 would leave 64% of it standing
+         before the ending had begun. */
       copy: phone
         ? [FLOOR[0], -FLOOR[3] + (FLOOR[1] + FLOOR[3]) * end, FLOOR[2], FLOOR[3]]
         : FLOOR,
@@ -963,27 +794,25 @@
 
   addEventListener('scroll', () => {
     /* Distance, not events: a trackpad fires far more scroll events per pixel
-       than a wheel does, and rating the boost by event count would make the
-       same gesture mean different things on different hardware. */
+       than a wheel, so rating the boost by event count would make one gesture
+       mean different things on different hardware. */
     vel += Math.abs(window.scrollY - lastY) / Math.max(innerHeight, 1);
     lastY = window.scrollY;
     wakeCaret();
-    /* When the ambient loop is running it is already drawing every frame, so
-       scheduling the scroll slot as well would render the same frame twice. */
+    /* When the ambient loop is running it already draws every frame, so
+       scheduling the scroll slot too would render the same frame twice. */
     if (ambient() && !still) { tick(); return; }
     if (!raf) raf = requestAnimationFrame(frame);
   }, { passive: true });
-  /* Coalesced through the same rAF slot as scroll. Dragging a window edge
-     fires resize continuously, and each one used to force a synchronous
-     measure — two forced layouts — plus a full GL draw, while also clearing
-     `raf` out from under a scroll frame that was already scheduled. The flag
-     is what keeps the measurement from being lost when that slot is taken. */
-  /* A resize preserves scrollY in both engines, so the reader's PIXEL
-     survived a rotation and their place in the argument did not — up to 3.2
-     sections in one gesture, and a fold-and-unfold destroyed the closing link
-     outright. Capture the dimensionless position before the layout changes
-     and restore it after; every layer that paints is position:fixed, so
-     re-anchoring the scroll is visually invisible. */
+  /* Coalesced through the same rAF slot as scroll: dragging a window edge fires
+     resize continuously, and each one used to force two layouts and a full GL
+     draw while clearing `raf` out from under a scroll frame already scheduled.
+     The flag keeps the measurement from being lost when that slot is taken.
+
+     And a resize preserves scrollY, so the reader's PIXEL survived a rotation
+     and their place in the argument did not — up to 3.2 sections in one
+     gesture. Capture the dimensionless position before the layout changes and
+     restore it after; every painting layer is fixed, so this is invisible. */
   let keepP = null, keepTail = 0;
   addEventListener('resize', () => {
     if (innerWidth !== lastW) { lastW = innerWidth; latchLVH(); }
@@ -996,8 +825,8 @@
   });
 
   /* Live preferences. Recomputing POINTER from the query rather than caching
-     its `.matches` keeps the two in step: reduced motion turns the pointer
-     light off regardless of what hardware is attached. */
+     `.matches` keeps the two in step: reduced motion turns the pointer light
+     off regardless of what hardware is attached. */
   const prefs = () => {
     const was = reduce;
     reduce  = mqReduce.matches;
@@ -1005,25 +834,24 @@
     if (!POINTER) { tgt[0] = tgt[1] = cur[0] = cur[1] = 0; }
     frame();
     /* Turning reduce back OFF left the loop dead for the rest of the visit:
-       frame() only re-arms via `act > 0.001`, and act is identically 0 on a
-       coarse pointer. tick()'s step self-terminates when ambient() is 0, so
-       this is safe in the forward direction too — it costs one frame. */
+       frame() only re-arms via `act > 0.001`, which is identically 0 on a
+       coarse pointer. Safe forward too — the step self-terminates when
+       ambient() is 0, at a cost of one frame. */
     if (was && !reduce) tick();
   };
   mqReduce.addEventListener('change', prefs);
   mqPointer.addEventListener('change', prefs);
   /* Measured, not assumed: the lockup's joined spacing is whatever normal flow
-     would have given it, which is only knowable once Cormorant has loaded. */
+     would give it, which is only knowable once Cormorant has loaded. */
   document.fonts.ready.then(() => { measure(); frame(); });
   measure();
   lastY = window.scrollY;
   frame();
   tick();          // and the field starts breathing, with nobody having done anything
 
-  /* Deterministic seeking, for tests and for screenshots. `t` is the film's,
-     so AT(i, 1) is the last frame of section i however much dead scroll the
-     page carries after it; on the last section t may run past 1, into the
-     tail, up to 1 + TAIL * S.length * H / film. */
+  /* Deterministic seeking, for tests and screenshots. `t` is the film's, so
+     AT(i, 1) is the last frame of section i however much dead scroll follows
+     it; on the last section t may run past 1, into the tail. */
   window.AT = (i, t) => {
     const max  = document.documentElement.scrollHeight - innerHeight;
     const film = filmLen();

--- a/src/ptl-page.js
+++ b/src/ptl-page.js
@@ -372,7 +372,10 @@
      The ending is the exception at both sizes: the lockup IS on the floor, so
      the phone's band grows out of the bottom edge to FLOOR's, on the same ramp
      that brings the dome up. */
-  const FLOOR = [-0.40, 0.10, 0.40, 0.21];
+  /* The field's, the same four numbers it defaults uCopy to. Fallback for the
+     same reason C has one: this file still seats the copy with no renderer. */
+  const FLOOR = (typeof PTLField !== 'undefined' && PTLField.FLOOR) ||
+                [-0.40, 0.10, 0.40, 0.21];
   /* Where the band's taper is half applied: the line, in the shader's own
      units, at which the picture gives way to the copy's ground. */
   const CLEARING = -(FLOOR[0] + FLOOR[1] + FLOOR[3] / 2);
@@ -569,13 +572,10 @@
      nothing else — and is monotonic. Nothing that decides where a word sits
      reads it, so at worst the halftone is a few frames further through a sine.
 
-     Scrolling makes it run faster: `vel` is scroll distance in viewport-heights
-     accumulated and decayed continuously, so the rate answers to how hard you
-     are moving rather than to whether an event fired. */
-  const AMB_IDLE = 1.0;    // clock seconds per real second, untouched
-  const AMB_GAIN = 5.5;    // extra, at full scroll speed
-  const AMB_DECAY = 0.86;  // how fast the boost bleeds off, per 60th of a second
-  let clock = 0, lastTs = 0, vel = 0, lastY = 0;
+     The clock ITSELF is the field's — it reaches uTime and nothing else, so it
+     lives with the thing it reaches, and about.html no longer keeps a second
+     copy of the arithmetic. What stays here is the pump: when to ask for a
+     frame, and when to stop. That is genuinely this page's business. */
   /* Ambient motion is motion, so reduced motion turns it off outright — and so
      does having nothing to move. The breathe reaches exactly one thing, mark
      size, so with no renderer mounted the loop held the compositor open at
@@ -598,16 +598,7 @@
     if (ticking) return;
     ticking = requestAnimationFrame(function step(ts) {
       ticking = 0;
-      /* Clamped for the one enormous delta a backgrounded tab hands back, and
-         ONLY that: past 0.5s is a returning tab, everything else is a slow
-         frame. Applied to every frame it ran the clock at 0.72 s/s at 15fps. */
-      const raw = lastTs ? (ts - lastTs) / 1000 : 0.016;
-      const dt  = raw > 0.5 ? 0.016 : Math.min(raw, 0.25);
-      lastTs = ts;
-      if (ambient()) {
-        vel *= Math.pow(AMB_DECAY, dt * 60);   // per second, not per frame
-        clock += dt * (AMB_IDLE + AMB_GAIN * Math.min(vel, 1.4));
-      }
+      if (field) field.frame(ts, ambient() === 1);
       const dx = tgt[0] - cur[0], dy = tgt[1] - cur[1];
       /* The chase rate eases on distance too: near the mark the light is
          attentive, far from it lazy — the shader's amplitude falloff on the
@@ -630,7 +621,7 @@
      first frame after does not carry the whole absence as one delta. */
   document.addEventListener('visibilitychange', () => {
     if (document.hidden) return;
-    lastTs = 0;
+    if (field) field.idle();
     tick();
   });
 
@@ -780,7 +771,7 @@
       lift: lift(),
       cell: 12, gap: 0.12, gain: 1.0,
       mouse: cur, act, ink: INK, ink2: INK2, paper: PAPER, tint: TINT,
-      time: clock, amb: ambient(), resolve: res,
+      amb: ambient(), resolve: res,
     });
   }
 
@@ -801,11 +792,7 @@
   }
 
   addEventListener('scroll', () => {
-    /* Distance, not events: a trackpad fires far more scroll events per pixel
-       than a wheel, so rating the boost by event count would make one gesture
-       mean different things on different hardware. */
-    vel += Math.abs(window.scrollY - lastY) / Math.max(innerHeight, 1);
-    lastY = window.scrollY;
+    if (field) field.scrolled();
     wakeCaret();
     /* When the ambient loop is running it already draws every frame, so
        scheduling the scroll slot too would render the same frame twice. */
@@ -853,7 +840,6 @@
      would give it, which is only knowable once Cormorant has loaded. */
   document.fonts.ready.then(() => { measure(); frame(); });
   measure();
-  lastY = window.scrollY;
   frame();
   tick();          // and the field starts breathing, with nobody having done anything
 


### PR DESCRIPTION
Only variation 1 ships. Everything that existed to support the other three is gone, and so is everything that turned out to be dead once they were.

**4,991 → 3,663 lines.** Variations 2, 3 and 4 are preserved at the tag `variants-2-3-4`.

| | before | after |
|---|---:|---:|
| `index.html` | 1422 | 1022 |
| `about.html` | 1219 | 1010 |
| `src/ptl-page.js` | 1077 | 855 |
| `src/ptl-field.js` | 1273 | **850** |

## The commits, in order

1. **Delete variations 2, 3 and 4.** `dataset.v` is permanently unset, so `SHADOW`, `TONE`, `PRINT` and `LATE` were constants. Folded: the `uShadow`/`uTone`/`uPrint` uniforms and their whole plumbing chain, the three `:root[data-v]` palette blocks, both `?v=` bootstrap scripts, the href carry-over, and the theme-color block that constant-folded to values already static in the markup.
2. **DRY the survivor** — 13 consolidations accepted, 13 rejected.
3. **Compress the commentary.** Shorter, not gutted. Every measured value that can't be re-derived survives (LCP 1640→1260ms, 82.8%, 96.7%); what went was variation 3's contrast figures, which died with the palette they justified.
4. **Delete the dead mode axis.** `mount()` was only ever called with `{mode:'form'}` and `draw()` never passed `o.mode`, so `uMode` was constantly 0 and the `ARCH` and `TYPE` treatments were unreachable — the same argument that retired the colourways. Gone with them: `uT`, `uSection`, `uTex`, `uFov`, `setWord()`, the type texture, `MODES`, and the six `data-key` attributes that fed it.
5. **One home for the field's vocabulary.** `about.html` reimplemented `clamp`/`lerp`/`smooth`/`hex3`/`mixHex`, and the copies had drifted: `hex3` expanded three-digit hex in one file and guarded a missing token in the other, so `--paper: #000` would have rendered on the front page and handed the shader `[NaN, NaN, NaN]` on the about page.
6. **One home for the ambient clock and the draw defaults.** Both pages had the same clock arithmetic, identical down to the constants — and both had *separately discovered the same two bugs in it* (the returning-tab delta, and a 60Hz-tuned decay bleeding off twice as fast at 120Hz). `feed()`'s two dozen `o.x != null ? o.x : …` lines are now a table.

## How this was verified

There is no test suite and the whole output is a WebGL halftone, so I built a render-equivalence harness: Playwright with a **faked monotonic clock** (`performance.now()` advancing a fixed 1000/60 ms per frame), sampling 28 scroll positions across both pages and comparing a 32×18 luminance signature.

It was validated before use by capturing an unmodified tree twice: 13 of 28 frames differed at the PNG-byte level while every signature delta was exactly **0** — so the signature is a zero-false-positive signal and PNG equality is not.

**Every commit above passes it: luminance delta 0 at all 28 positions, 0 console errors**, plus oxlint/knip/jscpd clean and a static check that every `var(--x)`, DOM id and GLSL uniform still resolves.

For commit 6 I also measured loop *arming* against the unmerged tree at three scroll positions on both pages — identical. Each page keeps its own rAF pump on purpose: they stop for genuinely different reasons, and moving them would have cost `ptl-page.js` its designed degradation (it still runs with no renderer at all).

## Two latent bugs in the tooling, found on the way — not fixed here

- **`pnpm dupes` scans zero files.** jscpd's default `maxLines` is 1000 and both sources exceed it, so it finishes in ~0.3ms having looked at nothing. `--max-lines 5000` fixes it.
- **All three gates take `src/` only.** ~2,000 lines of HTML are covered by nothing, and every GLSL symbol is invisible to knip and oxlint inside its template literal.

Left alone deliberately, since this PR is already large. There is also a **prioritised maintainability proposal** from a separate read that found real pre-existing issues this PR does not touch — notably `about.html`'s `og:description` describing the front page, and its draw call inheriting a landscape keep-out band it never asked for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2bSrQj3SpfaLsWQuRp494

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR collapses the site to its sole shipping visual variation and removes the renderer paths, palette switching, and mode infrastructure that supported the retired variants.
- Consolidates field helpers, animation timing, and draw defaults.
- Simplifies both pages and removes query-parameter variation propagation.
- Updates documentation to describe the single supported palette and reduced architecture.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Replaces multi-variation documentation with the single shipping palette and records the retired variants' archive tag. |
| about.html | Removes variation bootstrapping and duplicated field helpers while retaining guarded rendering and page-specific animation lifecycle behavior. |
| index.html | Removes alternate palette selectors and variation URL propagation so the page always uses variation 1. |
| src/ptl-field.js | Removes unreachable mode and variation uniforms, exports shared helpers, and centralizes frame timing and uniform defaults. |
| src/ptl-page.js | Simplifies choreography and renderer calls around the single supported field treatment. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Page as index/about page
  participant Choreography as ptl-page / page script
  participant Field as PTLField
  participant GL as WebGL2
  Page->>Choreography: load single palette and scroll state
  Choreography->>Field: mount(canvas)
  loop animation frame
    Choreography->>Field: frame(timestamp, motionEnabled)
    Choreography->>Field: draw(single-variation options)
    Field->>GL: update uniforms and render halftone
  end
```

<sub>Reviews (2): Last reviewed commit: ["Review fixes: stop a lost context loopin..."](https://github.com/predictive-text-labs/ptl-landing/commit/a664803a7f3edef43e5f3d44a61feda431149b6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52052330)</sub>

<!-- /greptile_comment -->