### PR TITLE
Resolve the fallback in the head, not a round trip later

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,18 @@
      the attribute is set here; the stylesheet below reads it. -->
     <script>
       {
+        /* Scripting is live — declared HERE, and for exactly the reason the
+       palette is. The fallback document at the end of the stylesheet below is
+       keyed on the ABSENCE of this flag, and the browser may paint as soon
+       as the body is parsed, which is one round trip before the two scripts at
+       the end of it can run. Set here, the fallback never applies to a scripted
+       page at all. Set from those scripts — which is where it used to be, as
+       `body.no-js` removed in ptl-page.js — it applied for as long as they took
+       to arrive: measured in Chrome, first contentful paint was the fallback
+       document at 192ms with a 500ms script fetch, and the flash lasted about
+       as long as the fetch. Nothing on localhost, which is why it only ever
+       showed on a cold first load. */
+        document.documentElement.dataset.js = "1";
         const v = new URLSearchParams(location.search).get("v");
         if (v === "2" || v === "3" || v === "4")
           document.documentElement.dataset.v = v;
@@ -1258,8 +1270,14 @@
       }
 
       /* Without script there is no film and no scroll choreography, so the copy
-     stops hiding and simply sets itself as a document. */
-      .no-js .story {
+     stops hiding and simply sets itself as a document.
+
+     Keyed on the absence of the head's flag rather than on a class the scripts
+     remove, so that the scripted page never wears these rules for even one
+     frame. The flag can also be taken back off at the end of the body — see the
+     guard after the two script tags — which is what covers a script that was
+     requested and never arrived. */
+      :root:not([data-js]) .story {
         position: static;
         width: auto;
         height: auto;
@@ -1271,7 +1289,7 @@
         padding: 6rem 2.4rem;
         margin-inline: auto;
       }
-      .no-js .story section + section {
+      :root:not([data-js]) .story section + section {
         margin-top: 4rem;
       }
       .story .sr {
@@ -1282,25 +1300,25 @@
         clip-path: inset(50%);
         white-space: nowrap;
       }
-      .no-js .story h1,
-      .no-js .story h2 {
+      :root:not([data-js]) .story h1,
+      :root:not([data-js]) .story h2 {
         font:
           300 clamp(1.6rem, 3vw, 2.4rem)/1.2 Cormorant,
           serif;
       }
-      .no-js .story p {
+      :root:not([data-js]) .story p {
         margin-top: 1.2rem;
         font:
           400 0.8rem/1.9 "Geist Mono",
           monospace;
         color: var(--mid);
       }
-      .no-js .stage {
+      :root:not([data-js]) .stage {
         display: none;
       }
     </style>
   </head>
-  <body class="no-js">
+  <body>
     <header class="chrome">
       <span class="wm">PREDICTIVE <br />TEXT LABS</span>
       <nav class="nav">
@@ -1418,5 +1436,27 @@
     </script>
     <script src="/src/ptl-field.js"></script>
     <script src="/src/ptl-page.js"></script>
+    <script>
+      /* The other half of the switch in the head. If ptl-page.js never arrived,
+     or threw on its way down, the film is not running and the argument is not
+     on the screen — so take the flag back off and let the fallback document
+     apply after all. This runs in the same parse as the two scripts above, so
+     the reader is never shown the empty state.
+
+     It waits on the flag ptl-page.js sets as its LAST statement, not on
+     evidence part-way through. #copy is filled early, a third of the way into
+     that file, and testing for it would call a boot that died after the copy
+     was built a success and hand the reader a blank page — which is the one
+     outcome the fallback exists to prevent.
+
+     The height goes back with it. A throw after the body has been stretched to
+     the film's full height leaves the fallback as one screen of words at the
+     top of eleven empty ones; the comment above the mount in ptl-page.js is
+     about that same failure. */
+      if (document.documentElement.dataset.ptl !== "live") {
+        delete document.documentElement.dataset.js;
+        document.body.style.height = "";
+      }
+    </script>
   </body>
 </html>

--- a/src/ptl-page.js
+++ b/src/ptl-page.js
@@ -854,7 +854,12 @@
       });
     }
   }
-  document.body.classList.remove('no-js');
+  /* The fallback document used to be dismissed here, by removing body.no-js.
+     That is one round trip too late to be invisible — the browser has been
+     entitled to paint the thing since the body finished parsing — so the
+     decision now sits in the head of index.html and this line is gone with it.
+     What is still owed from this file is the report that it finished, at the
+     very bottom. */
   document.body.style.height = ((S.length * PER + TAIL) * 100) + 'vh';
   let raf = 0, shown = -1, remeasure = false, lastW = innerWidth;
   let endU = -1;                          // last published --ending
@@ -1074,4 +1079,11 @@
     window.scrollTo(0, Math.min(max, film * ((i + t) / S.length)));
     render();
   };
+
+  /* Everything above ran. The guard at the end of index.html reads this and
+     leaves the scripted page alone; without it, it puts the fallback document
+     back. LAST STATEMENT ON PURPOSE — the whole value of the flag is that it
+     cannot be set by a file that stopped early, so nothing may be added below
+     it. */
+  document.documentElement.dataset.ptl = 'live';
 })();


### PR DESCRIPTION
On a cold first load the page's **first contentful paint was the no-JS fallback document** — all six beats stacked as a plain 44rem Cormorant column — which the film then replaced. That is the flash.

## What was happening

`<body class="no-js">` plus the fallback stylesheet turned the clipped `.story` into a real document and hid the stage (`.no-js .stage { display: none }`). The only thing that undid it was `classList.remove('no-js')` three quarters of the way down `src/ptl-page.js`, sitting behind two **parser-blocking** `<script src>` tags at the end of the body.

By the time the parser reaches those tags the body is fully parsed and laid out, so the browser has a complete render tree and paints it while both requests are still in flight. Captured at exactly that moment:

| at `<script src=ptl-field.js>` | before | after |
|---|---|---|
| `body` class | `no-js` | `""` |
| `#story` box | **704 × 1271px, 38.4px Cormorant** | 1 × 1px (clipped) |
| `.stage` (the film) | `display: none` | `display: block` |

## Why it looked intermittent

It is gated on script latency — which is why it showed on first open and never on reload. Chrome 151, three runs per rung, latency applied only to the two `/src/*.js` responses:

| script latency | flash painted | duration |
|---|---|---|
| 0ms (localhost) | 0/3 — none | — |
| 30ms | 1/3 | 10–50ms |
| 120ms | 2/3 | 118–244ms |
| 250ms | 3/3 | 230–308ms |
| 500ms | 3/3 | 336–494ms |
| 1000ms | 3/3 | 940–994ms |

At zero latency `no-js` comes off at 149ms and FCP lands at 244ms, so nothing wrong is ever shown. At 500ms, FCP is the fallback at 192ms with `stage: none` and `#copy` empty.

## The change

The decision moves into the head, where the palette switch already sits for [this exact reason](https://github.com/predictive-text-labs/PTL-Landing/blob/main/index.html#L26), and the fallback is keyed on the absence of that flag (`:root:not([data-js])`). With the flag set before `<body>` is parsed, a scripted page never wears those rules for a single frame — the flash becomes structurally impossible rather than merely shorter.

First paint becomes the ground plus the chrome header, which is already in its final position, and then the film.

The fallback must still appear when the film genuinely cannot run, so a guard after the two scripts takes the flag back off. It waits on a flag `ptl-page.js` sets as its **last statement** rather than on evidence part-way through: `#copy` is filled a third of the way into that file, so testing for it would score a boot that died afterwards as a success and hand the reader a blank page. The guard restores the body height too — a throw past the stretch to the film's full height otherwise leaves the fallback as one screen of words at the top of eleven empty ones, which is the failure the comment above the mount already describes.

## Verification

Headless Chrome 151, driven over CDP against these files:

| case | fallback readable | body height | |
|---|---|---|---|
| film runs | no | `1271vh` | PASS |
| scripting off | yes | unset | PASS |
| scripts 404 | yes | unset | PASS |
| throws mid-boot | yes | unset | PASS |

Nothing else moved:

- Settled film frame is **byte-identical** pre/post (`b018a8fd…`).
- All six beats seek correctly via `window.AT`, counter `01`→`06`, correct copy per beat; finale and `join us` CTA render.
- All four `?v=` colourways resolve, including `?v=9` falling back to variation 1, with `theme-color`/`color-scheme` still derived from `--paper`.
- `pnpm verify` clean (note it lints only the two `src` files — the `index.html` changes are covered by the browser checks above).

## Note

`about.html` doesn't share the pattern — its copy is static markup — so it is untouched.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves JavaScript capability detection into the document head to prevent the no-JS document from appearing during cold script fetches.
- Keys fallback styling on the absence of the root `data-js` attribute instead of a body class.
- Restores the readable fallback and resets body height when page initialization does not reach its final completion marker.
- Adds the completion marker as the final synchronous statement of page initialization.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the scripted and failed-initialization paths both preserving readable content.

The head flag prevents the transient fallback paint, while the final guard restores fallback styling and normal body height whenever synchronous page initialization fails to complete.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| index.html | Moves fallback selection into the head and adds a post-script recovery guard without revealing a concrete regression. |
| src/ptl-page.js | Replaces late body-class removal with a final initialization-completion marker consumed by the document guard. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Head script runs] --> B[Set data-js]
  B --> C[Parse body without fallback styles]
  C --> D[Load field and page scripts]
  D --> E{ptl-page reaches final statement?}
  E -->|Yes| F[Set data-ptl live]
  E -->|No| G[Post-script guard removes data-js]
  F --> H[Keep film presentation]
  G --> I[Reset body height]
  I --> J[Show readable fallback document]
```

<sub>Reviews (1): Last reviewed commit: ["Resolve the fallback in the head, not a ..."](https://github.com/predictive-text-labs/ptl-landing/commit/4e6ff8b1b234715281d433f5c685aad6b313d4b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52063823)</sub>

<!-- /greptile_comment -->