### PR TITLE
Reset the backers row, and let it break between the firms and the people

### DIFF
--- a/about.html
+++ b/about.html
@@ -880,17 +880,12 @@
               <li>Balaji Srinivasan</li>
               <li>Founders of Synthesia</li>
               <li>Founders of Supabase</li>
-              <li>Prime Beta</li>
-              <li>Florent</li>
-              <li>Roger Low</li>
-              <li>Georg Stockinger</li>
-              <li>Konstantin Richter</li>
-              <li>Nadav Eylath</li>
+              <li>Founders of Blockdaemon</li>
+              <li>Geeta Schmidt</li>
+              <li>Roger M Low</li>
               <li>Tony Liu</li>
               <li>Bjarke Klinge Staun</li>
-              <li>Geeta Schmidt</li>
               <li>Martine Niejadlik</li>
-              <li>Valerie Buresboenstroem</li>
               <li>and other angels</li>
             </ul>
           </div>

--- a/about.html
+++ b/about.html
@@ -880,9 +880,10 @@
               <li>Balaji Srinivasan</li>
               <li>Founders of Synthesia</li>
               <li>Founders of Supabase</li>
-              <li>Founders of Blockdaemon</li>
-              <li>Geeta Schmidt</li>
+              <li>Founder of Blockdaemon</li>
+              <li>Florent Venture Partners</li>
               <li>Roger M Low</li>
+              <li>Geeta Schmidt</li>
               <li>Tony Liu</li>
               <li>Bjarke Klinge Staun</li>
               <li>Martine Niejadlik</li>


### PR DESCRIPTION
Rewrites the backers row in the about page's footer. Markup only — no CSS, no script.

**The list, in order**

| | |
|---|---|
| 1 | Blackbird Ventures |
| 2 | Balaji Srinivasan |
| 3 | Founders of Synthesia |
| 4 | Founders of Supabase |
| 5 | Founder of Blockdaemon |
| 6 | Florent Venture Partners |
| 7 | Roger M Low |
| 8 | Geeta Schmidt |
| 9 | Tony Liu |
| 10 | Bjarke Klinge Staun |
| 11 | Martine Niejadlik |
| | and other angels |

**Entries that changed rather than moved**

- **Konstantin Richter → Founder of Blockdaemon**, singular. Three of the five companies on the row were already named as their founders; this makes it four, so the row reads as one pattern.
- **Florent → Florent Venture Partners.**
- **Roger Low → Roger M Low.**

**Five names come off:** Prime Beta, Georg Stockinger, Nadav Eylath, Valerie Buresboenstroem, and Konstantin Richter under his own name. The row already closes on `and other angels`, so nobody is left unaccounted for.

**Where the line breaks, and why no CSS was needed**

The row is a centred `flex-wrap`. At the widest it has **1331px** to work in — `.wrap` is 88rem less the page's padding — and the six firms measure **1255px** through Florent. Roger would carry the first line to **1389px**, 58px past the edge. So the break lands between the firms and the people by itself:

```
BLACKBIRD VENTURES · BALAJI SRINIVASAN · FOUNDERS OF SYNTHESIA · FOUNDERS OF SUPABASE · FOUNDER OF BLOCKDAEMON · FLORENT VENTURE PARTNERS
ROGER M LOW · GEETA SCHMIDT · TONY LIU · BJARKE KLINGE STAUN · MARTINE NIEJADLIK · AND OTHER ANGELS
```

Measured at 1920 / 1600 / 1440 / 1408 / 1366 / 1280 / 1180 / 1100 / 1024 / 900: **Geeta is on the second line at every one of them**, with no max-width set. Making her the second line's *first* word would mean widening the row by those 58px — the opposite of narrowing it — so nothing was added.

Below 900px the row wraps further and the split stops being firms-then-people; under 560px `.backers` switches to `display: block` and every name gets its own line. Both were already true of this footer.

**One spelling note.** The request wrote *Srinivisan*; the repo has *Srinivasan*, the spelling [#21](https://github.com/predictive-text-labs/PTL-Landing/pull/21) landed. I kept the repo's.

**Why nothing else needed touching.** `.backers` sets `text-transform: uppercase`, so source casing is invisible — `and other angels` stays lowercase in the markup and renders like the rest. The separator hangs off `li::after` with `:last-child::after` suppressed, so the row keeps its rules and ends without a trailing one. The `.up` reveal class is on the `<ul>`, not the items, so the staggered `nth-child` delays never applied per-name and the count does not matter to them.

**Checks.** `pnpm verify` clean (oxlint 0/0, knip clean, jscpd clean). Wrap positions measured in headless Chrome against the served build at fourteen viewport widths, after `document.fonts.ready` so Inter is the face being measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2bSrQj3SpfaLsWQuRp494

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the About page footer’s backers list by removing, renaming, and reordering entries.
- Replaces several individual backer names with updated person or organization labels.
- Shortens the list while preserving the closing “and other angels” entry.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| about.html | Updates static backer-list markup without changing styling, scripts, or page behavior. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Let the firms hold the first line and th..."](https://github.com/predictive-text-labs/ptl-landing/commit/1d9fa16e42903695c7d981df072f23c3ce5f066c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52225299)</sub>

<!-- /greptile_comment -->