### PR TITLE
Give Roger his middle initial

### DIFF
--- a/about.html
+++ b/about.html
@@ -882,7 +882,7 @@
               <li>Founders of Supabase</li>
               <li>Prime Beta</li>
               <li>Florent</li>
-              <li>Roger Low</li>
+              <li>Roger M Low</li>
               <li>Georg Stockinger</li>
               <li>Konstantin Richter</li>
               <li>Nadav Eylath</li>


### PR DESCRIPTION
`Roger Low` → `Roger M Low` in the backer list on the about page.

One line changed. The name appears nowhere else in the repo — `index.html`, the shaders and the JS never read it — so there is nothing downstream to follow.

Note: the open `reorder-backers` work already carries this spelling in its own commits, so whichever lands second will be a no-op on this line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2bSrQj3SpfaLsWQuRp494

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the About page’s backer list to display Roger Low’s middle initial.
- Changes “Roger Low” to “Roger M Low” in `about.html`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The change only updates static display text in an existing list item, with no behavioral, structural, or security impact.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| about.html | The static backer name is updated without affecting markup structure or application behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Give Roger his middle initial"](https://github.com/predictive-text-labs/ptl-landing/commit/5474d417e68e2e5af8df8fef061c706c3161a9e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52235978)</sub>

<!-- /greptile_comment -->